### PR TITLE
Manage autostart via the program, not the installer

### DIFF
--- a/build/builder/Data/InnoSetup.template
+++ b/build/builder/Data/InnoSetup.template
@@ -1,5 +1,5 @@
 [Tasks]
-Name: "desktopicon"; Description: {cm:CreateDesktopIcon}; GroupDescription: {cm:AdditionalIcons}; Flags: checkedonce 
+Name: "desktopicon"; Description: {cm:CreateDesktopIcon}; GroupDescription: {cm:AdditionalIcons}; Flags: checkedonce
 
 [Languages]
 Name: "en"; MessagesFile: "compiler:Default.isl"
@@ -70,8 +70,8 @@ Type: filesandordirs; Name: "{app}\drivers"
 Type: dirifempty; Name: "{app}"
 Type: files; Name: "{userstartup}\EventGhost.lnk"
 
-[Run] 
-Filename: "{app}\\EventGhost.exe"; Flags: postinstall nowait skipifsilent 
+[Run]
+Filename: "{app}\\EventGhost.exe"; Flags: postinstall nowait skipifsilent
 
 [Icons]
 Name: "{group}\EventGhost"; Filename: "{app}\EventGhost.exe"
@@ -79,15 +79,15 @@ Name: "{group}\EventGhost Help"; Filename: "{app}\EventGhost.chm"
 Name: "{group}\EventGhost Web Site"; Filename: "http://www.eventghost.net/"
 Name: "{group}\Uninstall EventGhost"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\EventGhost"; Filename: "{app}\EventGhost.exe"; Tasks: desktopicon
-Name: "{userstartup}\EventGhost"; Filename: "{app}\EventGhost.exe"; Parameters: "-h -e OnInitAfterBoot"; Flags: createonlyiffileexists 
+;Name: "{userstartup}\EventGhost"; Filename: "{app}\EventGhost.exe"; Parameters: "-h -e OnInitAfterBoot"; Flags: createonlyiffileexists
 
 [Registry]
 Root: HKCR; Subkey: ".egtree"; ValueType: string; ValueName: ""; ValueData: "EventGhost Tree"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "EventGhost Tree"; ValueType: string; ValueName: ""; ValueData: "EventGhost Tree"; Flags: uninsdeletekey
 Root: HKCR; Subkey: "EventGhost Tree\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\EventGhost.exe,0"
-Root: HKCR; Subkey: "EventGhost Tree\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EventGhost.exe"" ""%%1""" 
+Root: HKCR; Subkey: "EventGhost Tree\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EventGhost.exe"" ""%%1"""
 
 Root: HKCR; Subkey: ".egplugin"; ValueType: string; ValueName: ""; ValueData: "EventGhost Plugin"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "EventGhost Plugin"; ValueType: string; ValueName: ""; ValueData: "EventGhost Plugin"; Flags: uninsdeletekey
 Root: HKCR; Subkey: "EventGhost Plugin\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\EventGhost.exe,0"
-Root: HKCR; Subkey: "EventGhost Plugin\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EventGhost.exe"" ""%%1""" 
+Root: HKCR; Subkey: "EventGhost Plugin\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EventGhost.exe"" ""%%1"""

--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -86,7 +86,7 @@ class Config(Section):
         language = 'de_DE'
     else:
         language = 'en_EN'
-    startWithWindows = False
+    startWithWindows = True
     hideOnStartup = False
     checkUpdate = False
     logActions = True
@@ -132,6 +132,7 @@ class Config(Section):
                     raise
         else:
             eg.PrintDebugNotice('File "%s" does not exist.' % configFilePath)
+            eg.Utils.UpdateStartupShortcut(self.startWithWindows)
         if self.language == "Deutsch":
             self.language = "de_DE"
 

--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -201,26 +201,8 @@ class OptionsDialog(eg.TaskletDialog):
 
         oldLanguage = config.language
         while self.Affirmed():
-            tmp = startWithWindowsCtrl.GetValue()
-            if tmp != eg.config.startWithWindows:
-                config.startWithWindows = tmp
-                path = os.path.join(
-                    eg.folderPath.Startup,
-                    eg.APP_NAME + ".lnk"
-                )
-                if tmp:
-                    # create shortcut in autostart dir
-                    eg.Shortcut.Create(
-                        path=path,
-                        target=os.path.abspath(sys.executable),
-                        arguments="-h -e OnInitAfterBoot"
-                    )
-                else:
-                    # remove shortcut from autostart dir
-                    try:
-                        os.remove(path)
-                    except:
-                        pass
+            config.startWithWindows = startWithWindowsCtrl.GetValue()
+            eg.Utils.UpdateStartupShortcut(config.startWithWindows)
 
             config.hideOnClose = hideOnCloseCtrl.GetValue()
             config.useFixedFont = useFixedFontCtrl.GetValue()

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -24,6 +24,7 @@ __all__ = ["Bunch", "NotificationHandler", "LogIt", "LogItWithReturn",
 
 import eg
 import wx
+import os
 import sys
 import threading
 import time
@@ -486,4 +487,23 @@ def GetUpTime(seconds = True):
     ticks = GetTickCount64()/1000.0
     delta = str(td(seconds = ticks))
     return ticks if seconds else delta[:delta.index(".")]
+
+
+def UpdateStartupShortcut(create):
+    from eg import Shortcut
+
+    path = os.path.join(
+        eg.folderPath.Startup,
+        eg.APP_NAME + ".lnk"
+    )
+
+    if os.path.exists(path):
+        os.remove(path)
+
+    if create:
+        Shortcut.Create(
+            path=path,
+            target=os.path.abspath(sys.executable),
+            arguments="-h -e OnInitAfterBoot"
+        )
 


### PR DESCRIPTION
If you run EventGhost without "Autostart EventGhost on system startup" enabled in options (whether you don't want it running at startup at all or simply prefer to launch it another way), you've probably noticed the installer creates a Startup shortcut anyway every single time you upgrade. With this change, EventGhost now manages autostart entirely by itself, so your autostart setting will be respected on upgrade. Startup shortcuts will still be removed during uninstall.