### PR TITLE
Added a new event before leaving mainloop.

### DIFF
--- a/eg/Classes/App.py
+++ b/eg/Classes/App.py
@@ -160,6 +160,10 @@ class App(wx.App):
             eg.pyCrustFrame.Close()
         eg.document.Close()
         eg.taskBarIcon.Close()
+        eg.PrintDebugNotice("Triggering OnBeforeClose")
+        egEvent = eg.eventThread.TriggerEvent("OnBeforeClose")
+        while not egEvent.isEnded:
+            self.Yield()
         self.ExitMainLoop()
         return True
 


### PR DESCRIPTION
Send an event before the mainloop exits, so that plugins can be stopped clean. (e.g. Snarl plugin)