### PR TITLE
Create fully populated virtualenv via `--make-env`

### DIFF
--- a/build/builder/CheckDependencies.py
+++ b/build/builder/CheckDependencies.py
@@ -94,7 +94,7 @@ class ModuleDependency(DependencyBase):
 class PyWin32Dependency(DependencyBase):
     name = "pywin32"
     version = "220"
-    url = "https://sourceforge.net/projects/pywin32/files/pywin32/"
+    url = "https://eventghost.github.io/dist/dependencies/pywin32-220-cp27-none-win32.whl"
 
     def Check(self):
         versionFilePath = join(
@@ -127,7 +127,8 @@ class StacklessDependency(DependencyBase):
 class InnoSetupDependency(DependencyBase):
     name = "Inno Setup"
     version = "5.5.8"
-    url = "http://www.innosetup.com/isdl.php"
+    #url = "http://www.innosetup.com/isdl.php"
+    url = "http://www.innosetup.com/download.php/is-unicode.exe"
 
     def Check(self):
         if not GetInnoCompilerPath():
@@ -138,9 +139,10 @@ class InnoSetupDependency(DependencyBase):
 class HtmlHelpWorkshopDependency(DependencyBase):
     name = "HTML Help Workshop"
     version = "1.0"
+    #url = "https://www.microsoft.com/download/details.aspx?id=21138"
     url = (
-        "http://www.microsoft.com/Downloads/details.aspx?"
-        "familyid=00535334-C8A6-452F-9AA0-D597D16580CC&displaylang=en"
+        "https://download.microsoft.com/download"
+        "/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe"
     )
 
     def Check(self):
@@ -150,9 +152,10 @@ class HtmlHelpWorkshopDependency(DependencyBase):
 
 
 class DllDependency(DependencyBase):
+    #url = "https://www.microsoft.com/download/details.aspx?id=29"
     url = (
-        "http://www.microsoft.com/downloads/details.aspx?"
-        "displaylang=en&FamilyID=9b2da534-3e03-4391-8a4d-074b9f2bc1bf"
+        "https://download.microsoft.com/download"
+        "/1/1/1/1116b75a-9ec3-481a-a3c8-1777b5381140/vcredist_x86.exe"
     )
 
     def Check(self):
@@ -185,7 +188,7 @@ DEPENDENCIES = [
         name = "agithub",
         module = "agithub",
         version = "2.0",
-        url = "https://github.com/jpaugh/agithub/archive/v2.0.zip",
+        url = "https://eventghost.github.io/dist/dependencies/agithub-2.0-cp27-none-any.whl",
     ),
     ModuleDependency(
         name = "comtypes",
@@ -197,13 +200,13 @@ DEPENDENCIES = [
         name = "ctypeslib",
         module = "ctypeslib",
         version = "0.5.6",
-        url = "https://github.com/EventGhost/ctypeslib/archive/master.zip"
+        url = "https://eventghost.github.io/dist/dependencies/ctypeslib-0.5.6-cp27-none-any.whl"
     ),
     ModuleDependency(
         name = "future",
         module = "future",
         version = "0.15.2",
-        url = "http://pypi.python.org/pypi/future/"
+        url = None,
     ),
     HtmlHelpWorkshopDependency(),
     InnoSetupDependency(),
@@ -224,7 +227,7 @@ DEPENDENCIES = [
         name = "PyCrypto",
         module = "Crypto",
         version = "2.6.1",
-        url = None,
+        url = "https://eventghost.github.io/dist/dependencies/pycrypto-2.6.1-cp27-none-win32.whl",
     ),
     PyWin32Dependency(),
     ModuleDependency(
@@ -237,8 +240,8 @@ DEPENDENCIES = [
     ModuleDependency(
         name = "wxPython",
         module = "wx",
-        version = "3.0.2",
-        url = "http://www.wxpython.org/",
+        version = "3.0.2.0",
+        url = "https://eventghost.github.io/dist/dependencies/wxPython-3.0.2.0-cp27-none-win32.whl",
     ),
     DllDependency(name="msvcm90.dll", version="9.0.21022.8"),
     DllDependency(name="msvcp90.dll", version="9.0.21022.8"),

--- a/build/builder/CheckDependencies.py
+++ b/build/builder/CheckDependencies.py
@@ -143,6 +143,18 @@ class StacklessDependency(DependencyBase):
 
 
 
+class GitDependency(DependencyBase):
+    name = "Git"
+    version = "2.8.0"
+    package = "git"
+    url = "https://git-scm.com/download/win"
+
+    def Check(self):
+        if not (os.system('"%s" --version >NUL 2>NUL' % GetGitPath()) == 0):
+            raise MissingDependency
+
+
+
 class InnoSetupDependency(DependencyBase):
     name = "Inno Setup"
     version = "5.5.8"
@@ -232,6 +244,7 @@ DEPENDENCIES = [
         module = "future",
         version = "0.15.2",
     ),
+    #GitDependency(),
     HtmlHelpWorkshopDependency(),
     InnoSetupDependency(),
     DllDependency(
@@ -389,6 +402,14 @@ def GetChocolateyPath():
         "bin",
         "choco.exe",
     )
+    return path if exists(path) else ""
+
+
+def GetGitPath():
+    path = ""
+    for p in GetEnvironmentVar("PATH").split(os.pathsep):
+        if "\\Git\\" in p:
+            path = join(p, "git.exe")
     return path if exists(path) else ""
 
 

--- a/build/builder/CreateGitHubRelease.py
+++ b/build/builder/CreateGitHubRelease.py
@@ -40,6 +40,9 @@ class CreateGitHubRelease(builder.Task):
     description = "Create GitHub release"
     activated = False
 
+    def Setup(self):
+        self.enabled = bool(self.buildSetup.gitConfig["token"])
+
     def DoTask(self):
         buildSetup = self.buildSetup
         srcDir = buildSetup.sourceDir

--- a/build/builder/Gui.py
+++ b/build/builder/Gui.py
@@ -93,6 +93,9 @@ class MainDialog(wx.Dialog):
         grdSzr.Add(self.chcBranch, 0, wx.ALL, 5)
         ghSzr.Add(grdSzr, 1, wx.EXPAND)
 
+        if not self.buildSetup.gitConfig["token"]:
+            sb.Disable()
+
         egSzr = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, "EventGhost"), wx.HORIZONTAL)
 
@@ -112,6 +115,9 @@ class MainDialog(wx.Dialog):
         egSzr.Add(self.versionStr, 0, wx.ALIGN_CENTER_VERTICAL |
                   wx.LEFT | wx.RIGHT, 5)
         egSzr.Add(refreshVersion, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+
+        if not self.buildSetup.gitConfig["token"]:
+            refreshVersion.Disable()
 
         # combine all controls to a main sizer
         mainSizer = wx.BoxSizer(wx.VERTICAL)

--- a/build/builder/Utils.py
+++ b/build/builder/Utils.py
@@ -80,16 +80,20 @@ def GetRevision(buildSetup):
     """
     Get the app version and revision.
     """
-    print "getting version and revision from GitHub."
-    parts = GetLastReleaseOrTagName(buildSetup).split('.')[:3]
-    parts[0] = parts[0].strip('v')
-    while len(parts) < 3:
-        parts.append("0")
-    parts[2] = int(parts[2]) + 1
-    buildSetup.appVersion = '{0}.{1}.{2}'.format(*parts)
-    magic = 1722 - 1046  # Last SVN revision - total Git commits at r1722
-    commits = GetCommitCount(buildSetup)
-    buildSetup.appRevision = (commits + magic) if commits else 0
+    #print "getting version and revision from GitHub."
+    if buildSetup.gitConfig["token"]:
+        parts = GetLastReleaseOrTagName(buildSetup).split('.')[:3]
+        parts[0] = parts[0].strip('v')
+        while len(parts) < 3:
+            parts.append("0")
+        parts[2] = int(parts[2]) + 1
+        buildSetup.appVersion = '{0}.{1}.{2}'.format(*parts)
+        magic = 1722 - 1046  # Last SVN revision - total Git commits at r1722
+        commits = GetCommitCount(buildSetup)
+        buildSetup.appRevision = (commits + magic) if commits else 0
+    else:
+        buildSetup.appVersion = "0.0.0"
+        buildSetup.appRevision = 0
 
 
 def GetLastReleaseOrTagName(buildSetup):
@@ -221,7 +225,7 @@ def ListDir(path, skip_dirs=[], fullpath=True):
     return files
 
 
-def GetGithubConfig():
+def GetGitHubConfig():
     '''
     Get GitHub from .gitconfig .
     '''

--- a/build/builder/VirtualEnv.py
+++ b/build/builder/VirtualEnv.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.net/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+import sys
+from os.path import exists, expandvars, join
+
+
+_CODE_DEACTIVATE = 5000
+_CODE_RESTART = 6000
+
+ARGV = " ".join(["Build.py"] + sys.argv[1:])
+HOME = os.environ.get("WORKON_HOME", expandvars("%USERPROFILE%\Envs"))
+if hasattr(sys, "real_prefix"):
+    NAME = sys.prefix.split("\\")[-1]
+    PATH = sys.prefix
+else:
+    NAME = "eg-py%d%d" % sys.version_info[:2]
+    PATH = join(HOME, NAME)
+
+
+def Activate():
+    """
+    Activate the virtualenv for our Python version.
+    """
+    if not Running():
+        restarted = False
+        while True:
+            if exists(join(PATH, "Scripts", "slpython.exe")):
+                python = "slpython"
+            else:
+                python = "python"
+
+            exitCode = os.system(
+                ("%s %s && " % (join(PATH, "Scripts", "activate.bat"), NAME)) +
+                ("SET _REST=1 && " if restarted else "") +
+                ("%s %s" % (python, ARGV))
+            )
+
+            if exitCode == _CODE_DEACTIVATE:
+                break
+            elif exitCode == _CODE_RESTART:
+                restarted = True
+                continue
+            else:
+                sys.exit(exitCode)
+
+
+def Deactivate():
+    """
+    Deactivate the running virtualenv.
+    """
+    if Running():
+        sys.exit(_CODE_DEACTIVATE)
+
+
+def Exists():
+    """
+    Check if the virtualenv for our Python version exists.
+    """
+    return exists(PATH)
+
+
+def Restart():
+    """
+    Restart the running virtualenv.
+    """
+    if Running():
+        sys.exit(_CODE_RESTART)
+
+
+def Running():
+    """
+    Check if we're running inside a virtualenv.
+    """
+    return hasattr(sys, "real_prefix")
+

--- a/build/builder/__init__.py
+++ b/build/builder/__init__.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 from os.path import abspath, dirname, join
 
+from builder import VirtualEnv
 from builder.Utils import DecodePath, GetRevision, GetGithubConfig
 
 
@@ -47,6 +48,9 @@ class Task(object):
 
 class Builder(object):
     def __init__(self):
+        if not VirtualEnv.Running() and VirtualEnv.Exists():
+            VirtualEnv.Activate()
+
         global buildSetup
         Task.buildSetup = self
         buildSetup = self

--- a/build/builder/__init__.py
+++ b/build/builder/__init__.py
@@ -23,7 +23,7 @@ import tempfile
 from os.path import abspath, dirname, join
 
 from builder import VirtualEnv
-from builder.Utils import DecodePath, GetRevision, GetGithubConfig
+from builder.Utils import DecodePath, GetRevision, GetGitHubConfig
 
 
 class Task(object):
@@ -70,7 +70,7 @@ class Builder(object):
             sys.exit(1)
 
         try:
-            self.gitConfig = GetGithubConfig()
+            self.gitConfig = GetGitHubConfig()
         except ValueError:
             print ".gitconfig does not contain needed options. Please do:\n" \
                   "\t$ git config --global github.user <your github username>\n" \
@@ -78,8 +78,21 @@ class Builder(object):
                   "To create a token, go to: https://github.com/settings/tokens\n"
             exit(1)
         except IOError:
-            print "could not open .gitconfig."
-            exit(1)
+            print "WARNING: Git config not available; can't release to GitHub!"
+            self.gitConfig = {
+                "all_repos": {
+                    "EventGhost/EventGhost": {
+                        "all_branches": ["master"],
+                        "def_branch": "master",
+                        "name": "EventGhost",
+                    },
+                },
+                "branch": "master",
+                "repo": "EventGhost",
+                "repo_full": "EventGhost/EventGhost",
+                "token": "",
+                "user": "EventGhost",
+            }
 
         self.appVersion = None
         self.appRevision = None

--- a/build/builder/__init__.py
+++ b/build/builder/__init__.py
@@ -17,10 +17,12 @@
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
 
-import tempfile
+import argparse
 import sys
+import tempfile
 from os.path import abspath, dirname, join
-from Utils import DecodePath, GetRevision, GetGithubConfig
+
+from builder.Utils import DecodePath, GetRevision, GetGithubConfig
 
 
 class Task(object):
@@ -45,20 +47,24 @@ class Task(object):
 
 class Builder(object):
     def __init__(self):
-        from CheckDependencies import CheckDependencies
         global buildSetup
         Task.buildSetup = self
         buildSetup = self
+
+        self.args = self.ParseArgs()
         baseDir = dirname(DecodePath(__file__))
         self.sourceDir = abspath(join(baseDir, "../.."))
-        if not CheckDependencies(self):
-            sys.exit(1)
         self.websiteDir = join(self.sourceDir, "website")
         self.dataDir = abspath(join(baseDir, "Data"))
         self.pyVersionStr = "%d%d" % sys.version_info[:2]
         self.pyVersionDir = join(self.dataDir, "Python%s" % self.pyVersionStr)
         self.libraryName = "lib%s" % self.pyVersionStr
         self.libraryDir = join(self.sourceDir, self.libraryName)
+
+        from CheckDependencies import CheckDependencies
+        if not CheckDependencies(self):
+            sys.exit(1)
+
         try:
             self.gitConfig = GetGithubConfig()
         except ValueError:
@@ -70,10 +76,20 @@ class Builder(object):
         except IOError:
             print "could not open .gitconfig."
             exit(1)
+
         self.appVersion = None
         self.appRevision = None
         self.tmpDir = tempfile.mkdtemp()
         self.appName = self.name
+
+    def ParseArgs(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-m", "--make-env",
+            action="store_true",
+            help="auto-install dependencies into a virtualenv",
+        )
+        return parser.parse_args()
 
     def RunGui(self):
         from Tasks import TASKS


### PR DESCRIPTION
In preparation for #16 and in the interests of removing the tremendous barrier to entry that is setting up a build environment, using `python Build.py --make-env`, the build script can now create a virtualenv and automatically install all failed dependencies via `pip` and [`choco`](https://chocolatey.org/). At startup, the created virtualenv will automatically be activated if you didn't manually activate it yourself.

Current caveat: virtualenv must be created from an existing Stackless Python installation. Although the code is capable of installing Stackless Python into the virtualenv from a CPython installation, the resulting build is unusable.