### PR TITLE
Deprecate `eg.revision`, remove previously deprecated items

### DIFF
--- a/build/Build.py
+++ b/build/Build.py
@@ -184,7 +184,7 @@ class MyBuilder(builder.Builder):
             destName="pyw.exe"
         )
         inno.AddFile(
-            join(self.tmpDir, "VersionRevision.py"),
+            join(self.tmpDir, "VersionInfo.py"),
             destDir="eg\\Classes"
         )
         # create entries in the [InstallDelete] section of the Inno script to

--- a/build/builder/Gui.py
+++ b/build/builder/Gui.py
@@ -22,7 +22,7 @@ import threading
 import wx
 
 import builder
-from Utils import GetRevision, ParseVersion
+from Utils import GetVersion, ParseVersion
 
 class MainDialog(wx.Dialog):
 
@@ -191,7 +191,7 @@ class MainDialog(wx.Dialog):
 
 
     def RefreshVersion(self, event):
-        GetRevision(self.buildSetup)
+        GetVersion(self.buildSetup)
         self.versionStr.SetValue(self.buildSetup.appVersion)
 
 

--- a/build/builder/Tasks.py
+++ b/build/builder/Tasks.py
@@ -24,7 +24,7 @@ import builder
 
 class UpdateVersionFile(builder.Task):
     """
-    Update buildTime and revision for eg/Classes/VersionRevision.py
+    Write version information to eg/Classes/VersionInfo.py
     """
     description = "Update version file"
     enabled = False
@@ -32,14 +32,13 @@ class UpdateVersionFile(builder.Task):
     def DoTask(self):
         buildSetup = self.buildSetup
         buildSetup.buildTime = time.time()
-        filename = join(buildSetup.tmpDir, "VersionRevision.py")
+        filename = join(buildSetup.tmpDir, "VersionInfo.py")
         outfile = open(filename, "wt")
         major, minor, patch = buildSetup.appVersionShort.split('.')[:3]
         outfile.write("string = '{0}'\n".format(buildSetup.appVersion))
         outfile.write("major = {0}\n".format(major))
         outfile.write("minor = {0}\n".format(minor))
         outfile.write("patch = {0}\n".format(patch))
-        outfile.write("revision = {0}\n".format(buildSetup.appRevision))
         outfile.write("buildTime = {0}\n".format(buildSetup.buildTime))
         outfile.close()
 

--- a/build/builder/Utils.py
+++ b/build/builder/Utils.py
@@ -80,11 +80,11 @@ def ExecutePy(*args):
     return StartProcess(sys.executable, "-u", "-c", "\n".join(args))
 
 
-def GetRevision(buildSetup):
+def GetVersion(buildSetup):
     """
-    Get the app version and revision.
+    Get the app version.
     """
-    #print "getting version and revision from GitHub."
+    #print "getting version from GitHub."
     if buildSetup.gitConfig["token"] and buildSetup.args.version is None:
         parts = GetLastReleaseOrTagName(buildSetup).split('.')[:3]
         parts[0] = parts[0].strip('v')
@@ -93,9 +93,6 @@ def GetRevision(buildSetup):
         parts[2] = int(parts[2]) + 1
         buildSetup.appVersion = '{0}.{1}.{2}'.format(*parts)
         buildSetup.appVersionShort = buildSetup.appVersion
-        magic = 1722 - 1046  # Last SVN revision - total Git commits at r1722
-        commits = GetCommitCount(buildSetup)
-        buildSetup.appRevision = (commits + magic) if commits else 0
     else:
         buildSetup.appVersion, buildSetup.appVersionShort = (
             ParseVersion(buildSetup.args.version)

--- a/build/builder/__init__.py
+++ b/build/builder/__init__.py
@@ -25,7 +25,7 @@ from os.path import abspath, dirname, join
 import builder
 from builder import VirtualEnv
 from builder.Utils import (
-    DecodePath, GetRevision, GetGitHubConfig, ParseVersion,
+    DecodePath, GetVersion, GetGitHubConfig, ParseVersion,
 )
 
 
@@ -106,7 +106,6 @@ class Builder(object):
 
         self.appVersion = None
         self.appVersionShort = None
-        self.appRevision = 0
         self.tmpDir = tempfile.mkdtemp()
         self.appName = self.name
 
@@ -156,7 +155,7 @@ class Builder(object):
         self.config = Config(self, join(self.dataDir, "Build.ini"))
         for task in self.tasks:
             task.Setup()
-        GetRevision(self)
+        GetVersion(self)
         if self.showGui:
             import Gui
             Gui.Main(self)

--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -81,7 +81,7 @@ def RecursivePySave(obj, fileWriter, indent=""):
 
 
 class Config(Section):
-    revision = 0
+    version = eg.Version.string
     if LOCALE.GetLanguageName(LOCALE.GetSystemLanguage()) == 'German':
         language = 'de_DE'
     else:
@@ -139,7 +139,7 @@ class Config(Section):
 
 
     def Save(self):
-        self.revision = eg.revision
+        self.version = eg.Version.string
         configFile = open(self._configFilePath, 'w+')
         RecursivePySave(self, configFile.write)
         configFile.close()

--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -28,7 +28,6 @@ from threading import Lock
 class TreeStateData(eg.PersistentData):
     guid = None
     time = None
-    expandState = None # deprecated
     expanded = None
 
 

--- a/eg/Classes/EventGhostEvent.py
+++ b/eg/Classes/EventGhostEvent.py
@@ -131,7 +131,6 @@ class EventGhostEvent(object):
 
         eg.event = self
         eg.eventString = eventString
-        eg.EventString = eventString # eg.EventString is deprecated
 
         eventHandlerList = []
         for key, val in eg.eventTable.iteritems():

--- a/eg/Classes/Log.py
+++ b/eg/Classes/Log.py
@@ -198,7 +198,7 @@ class Log(object):
         if excInfo is None:
             excInfo = sys.exc_info()
         tbType, tbValue, tbTraceback = excInfo
-        slist = ['Traceback (most recent call last) (%d):\n' % eg.revision]
+        slist = ['Traceback (most recent call last) (%s):\n' % eg.Version.string]
         if tbTraceback:
             decode = codecs.getdecoder('mbcs')
             for fname, lno, funcName, text in extract_tb(tbTraceback)[skip:]:
@@ -220,7 +220,7 @@ class Log(object):
 
 
     def PrintStack(self, skip=0):
-        strs = ['Stack trace (most recent call last) (%d):\n' % eg.revision]
+        strs = ['Stack trace (most recent call last) (%s):\n' % eg.Version.string]
         strs += format_stack(sys._getframe().f_back)[skip:]
         error = "".join(strs)
         self.Write(error.rstrip() + "\n", ERROR_ICON)

--- a/eg/Classes/RootItem.py
+++ b/eg/Classes/RootItem.py
@@ -40,7 +40,7 @@ class RootItem(ContainerItem):
         self.guid = str(GUID.create_new())
         self.time = str(time.time())
         attr = []
-        attr.append(('Version', str(eg.revision)))
+        attr.append(('Version', str(eg.Version.string)))
         attr.append(('Guid', self.guid))
         attr.append(('Time', self.time))
         return attr, None

--- a/eg/Classes/TreeItem.py
+++ b/eg/Classes/TreeItem.py
@@ -152,7 +152,7 @@ class TreeItem(object):
         if isinstance(self, eg.RootItem):
             self.WriteXmlString(stream.write)
         else:
-            stream.write('<EventGhost Version="%s">\r\n' % str(eg.revision))
+            stream.write('<EventGhost Version="%s">\r\n' % str(eg.Version.string))
             self.WriteXmlString(stream.write, "    ")
             stream.write('</EventGhost>')
         xmlString = stream.getvalue()

--- a/eg/Classes/Version.py
+++ b/eg/Classes/Version.py
@@ -18,11 +18,9 @@
 
 class Version:
     try:
-        from VersionRevision import (
-            string, major, minor, patch, revision, buildTime
-        )
+        from VersionInfo import string, major, minor, patch, buildTime
         base = string
     except ImportError:
         base = string = "WIP"
-        major = minor = patch = revision = buildTime = 0
+        major = minor = patch = buildTime = 0
 

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -60,7 +60,7 @@ eg.sitePackagesDir = join(
     "lib%d%d" % sys.version_info[:2],
     "site-packages"
 )
-eg.revision = eg.Version.revision
+eg.revision = 2000  # Deprecated
 eg.startupArguments = eg.Cli.args
 eg.debugLevel = eg.startupArguments.debugLevel
 eg.systemEncoding = locale.getdefaultlocale()[1]

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -72,7 +72,6 @@ eg.globals.eg = eg
 eg.event = None
 eg.eventTable = {}
 eg.eventString = ""
-eg.EventString = "" # eg.EventString is deprecated
 eg.notificationHandlers = {}
 eg.programCounter = None
 eg.programReturnStack = []


### PR DESCRIPTION
Plugin developers should be aware that:

* `eg.revision`, a relic of our SVN days, is still present for now, but is no longer updated and should no longer be used.
* `eg.EventString`, which was long ago replaced by `eg.eventString`, is gone for good.