### PR TITLE
Add Wow6432Node key to Inno Setup detection

### DIFF
--- a/_build/builder/InnoSetup.py
+++ b/_build/builder/InnoSetup.py
@@ -95,7 +95,18 @@ def GetInnoCompilerPath():
         installPath = _winreg.QueryValueEx(key, "InstallLocation")[0]
         _winreg.CloseKey(key)
     except WindowsError:
-        return None
+        try:
+            key = _winreg.OpenKey(
+                _winreg.HKEY_LOCAL_MACHINE,
+                (
+                    "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\"
+                    "Uninstall\\Inno Setup 5_is1"
+                )
+            )
+            installPath = _winreg.QueryValueEx(key, "InstallLocation")[0]
+            _winreg.CloseKey(key)
+        except WindowsError:
+            return None
     installPath = join(installPath, "ISCC.exe")
     if not exists(installPath):
         return None


### PR DESCRIPTION
the original registry key didn't exist in my registry, I found another
that could be used. I added alongside the original one.