### PR TITLE
Parse documents starting with "<md>" as Markdown

### DIFF
--- a/_build/Build.py
+++ b/_build/Build.py
@@ -38,16 +38,17 @@ class MyBuilder(builder.Builder):
     mainScript = "EventGhost.pyw"
 
     includeModules = [
-        "wx",
-        "PIL",
+        "CommonMark",
         "comtypes",
-        "pywin32",
-        "pythoncom",
-        "isapi",
-        "win32com",
-        "docutils",
         "Crypto",
+        "docutils",
+        "isapi",
         "jinja2",
+        "PIL",
+        "pythoncom",
+        "pywin32",
+        "win32com",
+        "wx",
     ]
 
     excludeModules = [

--- a/_build/builder/CheckDependencies.py
+++ b/_build/builder/CheckDependencies.py
@@ -18,6 +18,7 @@
 
 import glob
 import os
+import pip
 import platform
 import re
 import shutil
@@ -158,7 +159,15 @@ class ModuleDependency(DependencyBase):
         elif hasattr(module, "version"):
             version = module.version
         else:
-            raise Exception("Can't get version information")
+            result = [
+                p.version
+                for p in pip.get_installed_distributions()
+                if str(p).startswith(self.name + " ")
+            ]
+            if result:
+                version = result[0]
+            else:
+                raise Exception("Can't get version information")
         if not isinstance(version, str):
             version = ".".join(str(x) for x in version)
         if CompareVersion(version, self.version) < 0:
@@ -202,6 +211,11 @@ DEPENDENCIES = [
         module = "agithub",
         version = "2.0",
         url = "https://eventghost.github.io/dist/dependencies/agithub-2.0-cp27-none-any.whl",
+    ),
+    ModuleDependency(
+        name = "CommonMark",
+        module = "CommonMark",
+        version = "0.7.0",
     ),
     ModuleDependency(
         name = "comtypes",

--- a/eg/Classes/AboutDialog.py
+++ b/eg/Classes/AboutDialog.py
@@ -316,10 +316,10 @@ class ChangelogPanel(HtmlPanel):
     @eg.LogIt
     def UpdateChangelog(self, changelogDatPath, text, digest):
         """
-        Parses the reStructuredText and stores a copy of the result in the
+        Parses the Markdown and stores a copy of the result in the
         eg.configDir to speed up loading.
         """
-        text = eg.Utils.DecodeReST(text)
+        text = eg.Utils.DecodeMarkdown(text)
         changelogDatFile = open(changelogDatPath, "wt")
         changelogDatFile.write(digest + "\n")
         changelogDatFile.write(text)

--- a/eg/Classes/HtmlWindow.py
+++ b/eg/Classes/HtmlWindow.py
@@ -25,7 +25,7 @@ from wx.html import (
 )
 
 # Local imports
-from eg.Utils import DecodeReST
+from eg.Utils import DecodeMarkdown, DecodeReST
 
 class HtmlWindow(wxHtmlWindow):
     basePath = None
@@ -88,9 +88,10 @@ class HtmlWindow(wxHtmlWindow):
         self.basePath = basePath
 
     def SetPage(self, html):
-        pos = html.find("<rst>")
-        if pos != -1:
-            html = DecodeReST(html[pos + 5:])
+        if html.startswith("<md>"):
+            html = DecodeMarkdown(html[4:])
+        elif html.startswith("<rst>"):
+            html = DecodeReST(html[5:])
         wxHtmlWindow.SetPage(
             self,
             '<html><body bgcolor="%s" text="%s">%s</body></html>' % (

--- a/eg/Classes/PluginInstall.py
+++ b/eg/Classes/PluginInstall.py
@@ -29,7 +29,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 # Local imports
 import eg
 from eg.Classes.Dialog import Dialog
-from eg.Utils import DecodeReST
+from eg.Utils import DecodeMarkdown, DecodeReST
 
 TEMPLATE = u"""
 <FONT SIZE=5><b>{name}</b></FONT>
@@ -130,9 +130,10 @@ class PluginInstall(object):
 
     def GetPluginData(self, pluginInfo):
         description = pluginInfo.englishDescription
-        pos = description.find("<rst>")
-        if pos != -1:
-            description = DecodeReST(description[pos + 5:])
+        if description.startswith("<md>"):
+            description = DecodeMarkdown(description[4:])
+        elif description.startswith("<rst>"):
+            description = DecodeReST(description[5:])
         iconData = base64.b64encode(str(pluginInfo.icon.pil.tobytes()))
         return {
             "name": pluginInfo.englishName,

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -114,9 +114,11 @@ def AppUrl(description, url):
         )
     else:
         return description
-    pos = description.find("<rst>")
-    if pos != -1:
-        description = description[pos + 5:]
+    if description.startswith("<md>"):
+        description = description[4:]
+        description = DecodeMarkdown(description)
+    elif description.startswith("<rst>"):
+        description = description[5:]
         description = DecodeReST(description)
     return description + txt
 
@@ -281,9 +283,14 @@ def GetFirstParagraph(text):
     The paragraph is returned as HTML.
     """
     text = text.lstrip()
-    pos = text.find("<rst>")
-    if pos != -1:
-        text = text[pos + 5:]
+    if text.startswith("<md>"):
+        text = text[4:]
+        text = DecodeMarkdown(text)
+        start = text.find("<p>")
+        end = text.find("</p>")
+        return text[start + 3:end].replace("\n", " ")
+    elif text.startswith("<rst>"):
+        text = text[5:]
         text = DecodeReST(text)
         start = text.find("<p>")
         end = text.find("</p>")
@@ -459,9 +466,17 @@ def SplitFirstParagraph(text):
     The paragraph is returned as HTML.
     """
     text = text.lstrip()
-    pos = text.find("<rst>")
-    if pos != -1:
-        text = text[pos + 5:]
+    if text.startswith("<md>"):
+        text = text[4:]
+        text = DecodeMarkdown(text)
+        start = text.find("<p>")
+        end = text.find("</p>")
+        return (
+            text[start + 3:end].replace("\n", " "),
+            text[end + 4:].replace("\n", " ")
+        )
+    elif text.startswith("<rst>"):
+        text = text[5:]
         text = DecodeReST(text)
         start = text.find("<p>")
         end = text.find("</p>")

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 import wx
+from CommonMark import commonmark
 from ctypes import c_ulonglong, windll
 from datetime import datetime as dt, timedelta as td
 from docutils.core import publish_parts as ReSTPublishParts
@@ -152,6 +153,9 @@ def AsTasklet(func):
     def Wrapper(*args, **kwargs):
         eg.Tasklet(func)(*args, **kwargs).run()
     return update_wrapper(Wrapper, func)
+
+def DecodeMarkdown(source):
+    return commonmark(source)
 
 def DecodeReST(source):
     #print repr(source)


### PR DESCRIPTION
With this change, plugin developers can now write their descriptions in Markdown by using "\<md\>". reStructuredText ("\<rst\>") and HTML are still supported.