### PR TITLE
Prevent hang on system resume when `eg.app.Restart()` is called

### DIFF
--- a/eg/Classes/App.py
+++ b/eg/Classes/App.py
@@ -59,10 +59,12 @@ class App(wx.App):
         eg.document.Close()
         eg.taskBarIcon.Close()
         if not eg.startupArguments.translate:
-            eg.PrintDebugNotice("Triggering OnClose")
-            egEvent = eg.eventThread.TriggerEvent("OnClose")
-            while not egEvent.isEnded:
-                self.Yield()
+            def DoOnClose():
+                eg.PrintDebugNotice("Triggering OnClose")
+                egEvent = eg.eventThread.TriggerEvent("OnClose")
+                while not egEvent.isEnded:
+                    self.Yield()
+            wx.CallAfter(DoOnClose)
         self.ExitMainLoop()
         return True
 


### PR DESCRIPTION
Remember, boys and girls -- even if you don't think it's a `wx` issue, jam a `wx.CallAfter()` in there anyway.

`wx.CallAfter()`: The solution to all of life's problems.

Resolves #85.