### PR TITLE
Make automatic log scrolling work at all window sizes

### DIFF
--- a/eg/Classes/MainFrame/LogCtrl.py
+++ b/eg/Classes/MainFrame/LogCtrl.py
@@ -264,7 +264,7 @@ class LogCtrl(wx.ListCtrl):
             self.Refresh()
 
     def Scroll(self):
-        if len(self.data) <= (self.GetTopItem() + self.GetCountPerPage() + 1):
+        if len(self.data) <= (self.GetTopItem() + self.GetCountPerPage() + 2):
             self.ScrollList(0, 1000000)
 
     @eg.AssertInMainThread


### PR DESCRIPTION
Resolves #97.