### PR TITLE
Prevent random traceback on Grab Text Item(s) action

### DIFF
--- a/plugins/Window/__init__.py
+++ b/plugins/Window/__init__.py
@@ -53,6 +53,7 @@ from eg.WinApi.Utils import (
 )
 from FindWindow import FindWindow
 from SendKeys import SendKeys
+from win32_ctrls import win32_ctrls
 
 eg.RegisterPlugin(
     name = "Window",
@@ -232,7 +233,6 @@ class GrabText(eg.ActionBase):
 
     def __call__(self, only_sel = False):
         self.only_sel = only_sel
-        from win32_ctrls import win32_ctrls
         res = []
         for hwnd in GetTargetWindows():
             if not IsWindow(hwnd):


### PR DESCRIPTION
Seemingly randomly, EventGhost will, until it's restarted, start spitting out the following traceback when this action is called:

```
C:\Program Files (x86)\EventGhost\plugins\Window\__init__.py:235: RuntimeWarning: Parent module 'eg.CorePluginModule.Window' not found while handling absolute import
  from win32_ctrls import win32_ctrls
Error in Action: "Grab Text Item(s): Return only selected item(s): False"
Traceback (most recent call last):
  File "C:\Program Files (x86)\EventGhost\eg\Classes\ActionBase.py", line 116, in CallWrapper
    return self(*args)
  File "C:\Program Files (x86)\EventGhost\plugins\Window\__init__.py", line 235, in __call__
    from win32_ctrls import win32_ctrls
ImportError: No module named win32_ctrls
```

We can avoid this by simply importing the module at startup.