### PR TITLE
Pass only decoded Unicode strings to TriggerEvent

### DIFF
--- a/plugins/Broadcaster/__init__.py
+++ b/plugins/Broadcaster/__init__.py
@@ -91,6 +91,7 @@ class Server(asyncore.dispatcher):
         if (not my_addr) or self.selfBroadcast:
             bits = data.split(self.payDelim)
             bits = [bit.decode(eg.systemEncoding) for bit in bits]
+            
             commandSize=len(bits)
             if commandSize==1:
                 self.plugin.TriggerEvent(bits[0])

--- a/plugins/Broadcaster/__init__.py
+++ b/plugins/Broadcaster/__init__.py
@@ -89,7 +89,8 @@ class Server(asyncore.dispatcher):
         my_addr = addr[0] in self.addresses
 
         if (not my_addr) or self.selfBroadcast:
-            bits = data.split(str(self.payDelim))
+            bits = data.split(self.payDelim)
+            bits = [bit.decode('utf-8') for bit in bits]
             commandSize=len(bits)
             if commandSize==1:
                 self.plugin.TriggerEvent(bits[0])

--- a/plugins/Broadcaster/__init__.py
+++ b/plugins/Broadcaster/__init__.py
@@ -90,7 +90,7 @@ class Server(asyncore.dispatcher):
 
         if (not my_addr) or self.selfBroadcast:
             bits = data.split(self.payDelim)
-            bits = [bit.decode('utf-8') for bit in bits]
+            bits = [bit.decode(eg.systemEncoding) for bit in bits]
             commandSize=len(bits)
             if commandSize==1:
                 self.plugin.TriggerEvent(bits[0])


### PR DESCRIPTION
Passing raw bytes received from UDP causes exceptions for non-Ascii characters. Change also allows for non-Ascii characters for the payload delimiter (previously caused an exception due to str() call).

See further explanation here:

http://www.eventghost.net/forum/viewtopic.php?f=4&t=8222&p=43750#p43750