### PR TITLE
Fixes incorrect reporting of the language in Windows

### DIFF
--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 import wx
+from locale import windows_locale
 from CommonMark import commonmark
 from ctypes import c_ulonglong, windll
 from datetime import datetime as dt, timedelta as td
@@ -42,6 +43,7 @@ __all__ = [
 ]
 
 USER_CLASSES = (type, ClassType)
+
 
 class Bunch(object):
     """
@@ -122,6 +124,7 @@ def AppUrl(description, url):
         description = DecodeReST(description)
     return description + txt
 
+
 def AssertInActionThread(func):
     if not eg.debugLevel:
         return func
@@ -133,9 +136,9 @@ def AssertInActionThread(func):
                 (func.__name__, func.__module__)
             )
         return func(*args, **kwargs)
-        return func(*args, **kwargs)
 
     return update_wrapper(AssertWrapper, func)
+
 
 def AssertInMainThread(func):
     if not eg.debugLevel:
@@ -151,10 +154,12 @@ def AssertInMainThread(func):
 
     return update_wrapper(AssertWrapper, func)
 
+
 def AsTasklet(func):
     def Wrapper(*args, **kwargs):
         eg.Tasklet(func)(*args, **kwargs).run()
     return update_wrapper(Wrapper, func)
+
 
 def CollectGarbage():
     import gc
@@ -176,8 +181,10 @@ def CollectGarbage():
     #from pprint import pprint
     #pprint(gc.garbage)
 
+
 def DecodeMarkdown(source):
     return commonmark(source)
+
 
 def DecodeReST(source):
     #print repr(source)
@@ -188,6 +195,7 @@ def DecodeReST(source):
     )
     #print repr(res)
     return res['body']
+
 
 def EnsureVisible(window):
     """
@@ -250,10 +258,12 @@ def EnsureVisible(window):
     # set the new position and size
     window.SetRect((left, top, right - left, bottom - top))
 
+
 def EqualizeWidths(ctrls):
     maxWidth = max((ctrl.GetBestSize()[0] for ctrl in ctrls))
     for ctrl in ctrls:
         ctrl.SetMinSize((maxWidth, -1))
+
 
 def ExecFile(filename, globals=None, locals=None):
     """
@@ -263,6 +273,7 @@ def ExecFile(filename, globals=None, locals=None):
     FSE = sys.getfilesystemencoding()
     flnm = filename.encode(FSE) if isinstance(filename, unicode) else filename
     return execfile(flnm, globals, locals)
+
 
 def GetBootTimestamp(unix_timestamp = True):
     """
@@ -279,21 +290,28 @@ def GetBootTimestamp(unix_timestamp = True):
         return st if "." not in st else st[:st.index(".")]
     return now - up
 
+
 def GetClosestLanguage():
     """
     Returns the language file closest to system locale.
     """
     langDir = join(dirname(abspath(sys.executable)), "languages")
     if exists(langDir):
-        locale = wx.Locale()
-        name = locale.GetLanguageCanonicalName(locale.GetSystemLanguage())
-        if exists(join(langDir, name + ".py")):
-            return name
-        else:
-            for f in [f for f in os.listdir(langDir) if f.endswith(".py")]:
-                if f.startswith(name[0:3]):
-                    return f[0:5]
-    return "en_EN"
+        uiLang = windows_locale[windll.kernel32.GetUserDefaultUILanguage()]
+
+        langFiles = tuple(
+            f[:-3] for f in os.listdir(langDir)
+            if f.endswith(".py") and (
+                f.startswith(uiLang) or f.startswith(uiLang[:3])
+            )
+        )
+        if uiLang in langFiles:
+            return uiLang
+        if langFiles:
+            return langFiles[0]
+
+    return "en_US"
+
 
 def GetFirstParagraph(text):
     """
@@ -323,6 +341,7 @@ def GetFirstParagraph(text):
             result += " " + line
         return ' '.join(result.split())
 
+
 def GetFuncArgString(func, args, kwargs):
     classname = ""
     argnames = inspect.getargspec(func)[0]
@@ -340,6 +359,7 @@ def GetFuncArgString(func, args, kwargs):
     fname = classname + func.__name__
     return fname, "(" + ", ".join(res) + ")"
 
+
 def GetMyRepresentation(value):
     """
     Give a shorter representation of some wx-objects. Returns normal repr()
@@ -352,6 +372,7 @@ def GetMyRepresentation(value):
     if typeString.startswith("<class 'wx._controls."):
         return "=<wx.%s>" % typeString[len("<class 'wx._controls."): -2]
     return "=" + repr(value)
+
 
 def GetTopLevelWindow(window):
     """
@@ -367,7 +388,8 @@ def GetTopLevelWindow(window):
             return parent
         result = parent
 
-def GetUpTime(seconds = True):
+
+def GetUpTime(seconds=True):
     """
     Returns a runtime of system in seconds.
     If seconds == False, returns the number of days, hours, minutes and seconds.
@@ -380,17 +402,20 @@ def GetUpTime(seconds = True):
         return delta if "." not in delta else delta[:delta.index(".")]
     return ticks
 
+
 def IsVista():
     """
     Determine if we're running Vista or higher.
     """
     return (sys.getwindowsversion()[0] >= 6)
 
+
 def IsXP():
     """
     Determine if we're running XP or higher.
     """
     return (sys.getwindowsversion()[0:2] >= (5, 1))
+
 
 def LogIt(func):
     """
@@ -408,6 +433,7 @@ def LogIt(func):
         return func(*args, **kwargs)
     return update_wrapper(LogItWrapper, func)
 
+
 def LogItWithReturn(func):
     """
     Logs the function call and return, if eg.debugLevel is set.
@@ -422,6 +448,7 @@ def LogItWithReturn(func):
         eg.PrintDebugNotice(funcName + " => " + repr(result))
         return result
     return update_wrapper(LogItWithReturnWrapper, func)
+
 
 def ParseString(text, filterFunc=None):
     start = 0
@@ -453,6 +480,7 @@ def ParseString(text, filterFunc=None):
     chunks.append(text[start:])
     return "".join(chunks)
 
+
 def PrepareDocstring(docstring):
     """
     Convert a docstring into lines of parseable reST.  Return it as a list of
@@ -482,6 +510,7 @@ def PrepareDocstring(docstring):
         lines.append('')
     return "\n".join(lines)
 
+
 def Reset():
     eg.stopExecutionFlag = True
     eg.programCounter = None
@@ -490,6 +519,7 @@ def Reset():
     eg.actionThread.ClearPendingEvents()
     eg.PrintError("Execution stopped by user")
 
+
 def SetDefault(targetCls, defaultCls):
     targetDict = targetCls.__dict__
     for defaultKey, defaultValue in defaultCls.__dict__.iteritems():
@@ -497,6 +527,7 @@ def SetDefault(targetCls, defaultCls):
             setattr(targetCls, defaultKey, defaultValue)
         elif type(defaultValue) in USER_CLASSES:
             SetDefault(targetDict[defaultKey], defaultValue)
+
 
 def SplitFirstParagraph(text):
     """
@@ -535,6 +566,7 @@ def SplitFirstParagraph(text):
             result += " " + line
         return ' '.join(result.split()), remaining
 
+
 def TimeIt(func):
     """ Decorator to measure the execution time of a function.
 
@@ -551,6 +583,7 @@ def TimeIt(func):
         return res
 
     return update_wrapper(TimeItWrapper, func)
+
 
 def UpdateStartupShortcut(create):
     from eg import Shortcut


### PR DESCRIPTION
Changed using wx.local to ctypes to get the language.

Example of Bug:
Say you live in Germany but are English speaking. So you have the system locale set to Germany but the UI displayed language is in English. Using wx.locale would report back as de_DE even if the UI is set to en_US.

This fix reports the current displayed Windows GUI language. Not the system locale language.

Updated the code in the GetClosestLanguage() function so it only has one iteration and does any comparisons during the iteration.
Added a second line between function declarations in the Utils.py file to be pep8 compliant.
Removed an unreachable return statement.