### PR TITLE
Change the MainFrame to use wx.agw.aui instead of wx.aui

### DIFF
--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -119,13 +119,13 @@ class MainFrame(wx.Frame):
             )
         )
 
-        self.logCtrl, logPane = self.CreateLogCtrl()
+        self.logCtrl = self.CreateLogCtrl()
         self.corConst = (
             self.logCtrl.GetWindowBorderSize()[0] +
             wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
         )
-        self.treeCtrl, treePane = self.CreateTreeCtrl()
-        self.toolBar, toolBarPane = self.CreateToolBar()
+        self.treeCtrl = self.CreateTreeCtrl()
+        self.toolBar = self.CreateToolBar()
         self.menuBar = self.CreateMenuBar()
         self.statusBar = StatusBar(self)
         self.SetStatusBar(self.statusBar)
@@ -169,14 +169,15 @@ class MainFrame(wx.Frame):
             try:
                 auiManager.LoadPerspective(Config.perspective, False)
                 if Config.perspective.find('name=toolBar') == -1:
+                    treePane = auiManager.GetPane(self.treeCtrl)
+                    logPane = auiManager.GetPane(self.logCtrl)
+                    toolBarPane = auiManager.GetPane(self.toolBar)
                     treeFloating = treePane.IsFloating()
                     logPane.Dock()
                     treePane.Dock()
-                    auiManager.Update()
                     treePane.Floatable(True).Dockable(True).Right()
                     logPane.Floatable(False).Center()
                     toolBarPane.Show(False)
-                    auiManager.Update()
                     if treeFloating:
                         treePane.Float()
                     toolBarPane.Show(Config.showToolbar)
@@ -271,7 +272,7 @@ class MainFrame(wx.Frame):
         self.auiManager.Update()
 
         logCtrl.Thaw()
-        return logCtrl, pane
+        return logCtrl
 
     def CreateMenuBar(self):
         """
@@ -451,7 +452,7 @@ class MainFrame(wx.Frame):
         pane.Show(Config.showToolbar)
         self.auiManager.Update()
 
-        return toolBar, pane
+        return toolBar
 
     def CreateTreeCtrl(self):
         treeCtrl = TreeCtrl(self, document=self.document)
@@ -464,7 +465,7 @@ class MainFrame(wx.Frame):
         self.auiManager.Update()
 
         treeCtrl.SetFocus()
-        return treeCtrl, pane
+        return treeCtrl
 
     def CreateTreePopupMenu(self):
         """

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -275,8 +275,8 @@ class MainFrame(wx.Frame):
         Append("Open", "\tCtrl+O")
         Append("Save", "\tCtrl+S").Enable(False)
         Append("SaveAs", "\tShift+Ctrl+S")
-        #menu.AppendSeparator()
-        #Append("Options", "\tCtrl+P")
+        menu.AppendSeparator()
+        Append("Options", "\tCtrl+P")
         menu.AppendSeparator()
         Append("Restart", "\tShift+Ctrl+~")
         menu.AppendSeparator()
@@ -336,10 +336,6 @@ class MainFrame(wx.Frame):
         Append("Execute", "\tF5")
         menu.AppendSeparator()
         Append("Disabled", "\tCtrl+D", kind=wx.ITEM_CHECK)
-
-        # settings menu
-        settingsMenu = eg.SettingsMenu(ID)
-        menuBar.Append(settingsMenu, settingsMenu.GetTitle())
 
         # help menu
         menu = wx.Menu()
@@ -631,7 +627,7 @@ class MainFrame(wx.Frame):
 
     def OnPaneClose(self, event):
         """
-        React to a aui.EVT_AUI_PANE_CLOSE event.
+        React to a wx.lib.agw.aui.EVT_AUI_PANE_CLOSE event.
 
         Monitors if the toolbar gets closed and updates the check menu
         entry accordingly

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -105,8 +105,19 @@ class MainFrame(wx.Frame):
         )
         self.SetMinSize((400, 200))
         document.frame = self
-        self.auiManager = auiManager = aui.AuiManager()
-        auiManager.SetManagedWindow(self)
+        self.auiManager = auiManager = aui.AuiManager(
+            self,
+            agwFlags=(
+                aui.AUI_MGR_ALLOW_ACTIVE_PANE |
+                aui.AUI_MGR_TRANSPARENT_DRAG |
+                aui.AUI_MGR_LIVE_RESIZE |
+                aui.AUI_MGR_ANIMATE_FRAMES |
+                aui.AUI_MGR_AERO_DOCKING_GUIDES |
+                aui.AUI_MGR_PREVIEW_MINIMIZED_PANES |
+                aui.AUI_MGR_SMOOTH_DOCKING |
+                aui.AUI_MGR_DEFAULT
+            )
+        )
 
         self.logCtrl, logPane = self.CreateLogCtrl()
         self.corConst = (

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -113,7 +113,6 @@ class MainFrame(wx.Frame):
                 aui.AUI_MGR_LIVE_RESIZE |
                 aui.AUI_MGR_ANIMATE_FRAMES |
                 aui.AUI_MGR_AERO_DOCKING_GUIDES |
-                aui.AUI_MGR_PREVIEW_MINIMIZED_PANES |
                 aui.AUI_MGR_SMOOTH_DOCKING |
                 aui.AUI_MGR_DEFAULT
             )
@@ -171,21 +170,29 @@ class MainFrame(wx.Frame):
                 if Config.perspective.find('name=toolBar') == -1:
                     treePane = auiManager.GetPane(self.treeCtrl)
                     logPane = auiManager.GetPane(self.logCtrl)
-                    toolBarPane = auiManager.GetPane(self.toolBar)
+
                     treeFloating = treePane.IsFloating()
                     logPane.Dock()
                     treePane.Dock()
-                    treePane.Floatable(True).Dockable(True).Right()
-                    logPane.Floatable(False).Center()
+                    auiManager.Update()
+
+                    self.SetPaneProperties()
+
+                    toolBarPane = auiManager.GetPane(self.toolBar)
                     toolBarPane.Show(False)
+                    toolBarPane.Show(Config.showToolbar)
+
                     if treeFloating:
                         treePane.Float()
-                    toolBarPane.Show(Config.showToolbar)
+
                     auiManager.Update()
                     Config.perspective = self.auiManager.SavePerspective()
                     eg.config.Save()
             except:
-                pass
+                self.SetPaneProperties()
+        else:
+            self.SetPaneProperties()
+
         artProvider = auiManager.GetArtProvider()
         artProvider.SetMetric(aui.AUI_DOCKART_PANE_BORDER_SIZE, 0)
         artProvider.SetMetric(
@@ -257,6 +264,18 @@ class MainFrame(wx.Frame):
         def __del__(self):
             pass
 
+    def SetPaneProperties(self):
+        treePane = self.auiManager.GetPane(self.treeCtrl)
+        logPane = self.auiManager.GetPane(self.logCtrl)
+
+        treePane.MaximizeButton(True).MinimizeButton(True).Right()
+        treePane.CloseButton(False).Floatable(True).Dockable(True)
+
+        logPane.MaximizeButton(True).MinimizeButton(True).Center()
+        logPane.CloseButton(False).Floatable(False).Dockable(True)
+
+        self.auiManager.Update()
+
     def CreateLogCtrl(self):
         logCtrl = LogCtrl(self)
         logCtrl.Freeze()
@@ -266,8 +285,8 @@ class MainFrame(wx.Frame):
 
         pane = aui.AuiPaneInfo()
         pane.Name("logger").Caption(" " + Text.Logger.caption)
-        pane.MaximizeButton(True).CloseButton(False).MinSize((100, 100))
-        pane.Floatable(False).Center().Dockable(False)
+        pane.Center().MinSize((100, 100))
+
         self.auiManager.AddPane(logCtrl, pane)
         self.auiManager.Update()
 
@@ -444,7 +463,7 @@ class MainFrame(wx.Frame):
 
         pane = aui.AuiPaneInfo()
         pane.Name("toolBar").Caption(" Toolbar").Top().Row(0)
-        pane.MaximizeButton(False).CloseButton(False)
+        pane.MaximizeButton(False).MinimizeButton(True).CloseButton(True)
         pane.Floatable(True).Dockable(True).ToolbarPane()
         self.auiManager.AddPane(toolBar, pane)
         self.auiManager.Update()
@@ -458,9 +477,9 @@ class MainFrame(wx.Frame):
         treeCtrl = TreeCtrl(self, document=self.document)
 
         pane = aui.AuiPaneInfo()
-        pane.Name("tree").Caption(" " + Text.Tree.caption).Right()
-        pane.MaximizeButton(True).CloseButton(False).MinSize((100, 100))
-        pane.Floatable(True).Dockable(True)
+        pane.Name("tree").Caption(" " + Text.Tree.caption)
+        pane.Right().MinSize((100, 100))
+
         self.auiManager.AddPane(treeCtrl, pane)
         self.auiManager.Update()
 


### PR DESCRIPTION
Changed the AUI from wx.aui to wx.lib.agw.aui
Changed the ToolBar to an AuiPane
Updated the code for the adding of the treeCtrl pane as well as the logCtrlPane
Removed the "&" from the tool tips (short tool help) for the ToolBar items
Removed the double entries for setting the captions on the treeCtrl pane and the logCtrl pane

This update allows for the displaying of docking guides as well as a more fine grained control over the AUI for future enhancements.