### PR TITLE
Adds GUID to treeItems

### DIFF
--- a/eg/Classes/GUID.py
+++ b/eg/Classes/GUID.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.org/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+import comtypes
+
+
+class GUIDBase(object):
+
+    def __init__(self, target, guid=None):
+        self.target = target
+        if guid is None:
+            guid = comtypes.GUID.create_new()
+        else:
+            try:
+                guid = comtypes.GUID(guid)
+            except WindowsError:
+                guid = comtypes.GUID.create_new()
+        self.guid = str(guid)
+
+    def __repr__(self):
+        return "eg.GUID('%s')" % self.guid
+
+    def __str__(self):
+        return self.guid
+
+    def __unicode__(self):
+        return unicode(self.guid)
+
+    def __getattr__(self, item):
+        if item in self.__dict__:
+            return self.__dict__[item]
+
+        if hasattr(self.target, item):
+            return getattr(self.target, item)
+
+        raise AttributeError('%r does not have attribute %r' % (self, item))
+
+    def __call__(self):
+        return self.target
+
+
+class GUID(object):
+    def __init__(self):
+        self.guidObjects = {}
+
+    def NewId(self, target):
+        guid = GUIDBase(target)
+        self.guidObjects[guid.guid] = guid
+        return guid
+
+    def AddId(self, target, guid):
+        guid = GUIDBase(target, guid)
+        self.guidObjects[guid.guid] = guid
+        return guid
+
+    def __call__(self, guid):
+        if guid in self.guidObjects:
+            return self.guidObjects[guid]
+        try:
+            return self.guidObjects[guid.guid]
+        except KeyError:
+            raise AttributeError('%r has no attribute %r' % (self, guid))

--- a/eg/Classes/TreeItem.py
+++ b/eg/Classes/TreeItem.py
@@ -20,6 +20,7 @@ import wx
 import xml.etree.cElementTree as ElementTree
 from cStringIO import StringIO
 from xml.sax.saxutils import escape, quoteattr
+from comtypes import GUID
 
 # Local imports
 import eg
@@ -52,6 +53,7 @@ class TreeItem(object):
     document = None
     root = None
     icon = None
+    guid = None
 
     @eg.AssertInActionThread
     def __init__(self, parent, node):
@@ -60,6 +62,13 @@ class TreeItem(object):
         node.attrib = dict([(k.lower(), v) for k, v in node.attrib.items()])
         get = node.attrib.get
         self.name = get("name", "")
+        guid = get("xml_guid", None)
+        if guid is None:
+            eg.document.SetIsDirty(True)
+            self.guid = eg.GUID.NewId(self)
+        else:
+            self.guid = eg.GUID.AddId(self, guid)
+            
         if isinstance(self.name, str):
             self.name = unicode(self.name, "utf8")
         self.isEnabled = not get('enabled') == "False"
@@ -212,6 +221,7 @@ class TreeItem(object):
             attr.append(('id', self.xmlId))
         if not self.isEnabled:
             attr.append(('Enabled', 'False'))
+        attr.append(('XML_Guid', str(self.guid)))
         return attr, None
 
     def GetDependantsOutside(self, allItems):

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -86,6 +86,7 @@ eg.currentItem = None
 eg.actionGroup = eg.Bunch()
 eg.actionGroup.items = []
 eg.folderPath = eg.FolderPath()
+eg.GUID = eg.GUID()
 
 def _CommandEvent():
     """Generate new (CmdEvent, Binder) tuple


### PR DESCRIPTION
Adds a unique GUID to each treeItem
GUID is saved into the .egtree xml file
Allows for programatically accessing actions like Jump, DisableItem, EnableItem. 

Example: eg.plugins.EventGhost.EnableItem(eg.GUID('{11FA2BD4-D0C8-44D4-B842-4F7E3B9C0145}'))

Existing XmlIdLink has not been removed. this works next to it very similiar in fashion. only diference is this object when repr'd is callable.