### PR TITLE
Fix typo in build warning message

### DIFF
--- a/_build/builder/CheckSourceCode.py
+++ b/_build/builder/CheckSourceCode.py
@@ -129,7 +129,7 @@ class CheckSourceCode(builder.Task):
         sourceFile = open(path, "rt")
         for line in sourceFile.readlines():
             if len(line.rstrip()) > 79:
-                print "line to long", path, line.rstrip()
+                print "line too long", path, line.rstrip()
                 return
 
     def FixTrailingWhitespace(self, path):


### PR DESCRIPTION
"line to long" --> "line too long"