### PR TITLE
Ask to delete config data of plugin if uninstalled

### DIFF
--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -81,7 +81,7 @@ class Config(PersistentData.PersistentDataBase):
                 None,
                 message=(
                     'Configuration file does not exist.\n'
-                    'Would you like to create a new file?\n\n'
+                    'Would you like to create a new file?\n%s\n\n'
                     % self._configFilePath
                 ),
                 caption='Configuration Load Error',

--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -71,7 +71,9 @@ class Config(PersistentData.PersistentDataBase):
 
         PersistentData.PersistentDataBase.__init__(self, self, '')
 
-        self.Load()
+        if Cli.args.isMain:
+            self.Load()
+
         self.version = Version.string
 
     def Load(self):

--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -71,7 +71,7 @@ class Config(PersistentData.PersistentDataBase):
 
         PersistentData.PersistentDataBase.__init__(self, self, '')
 
-        if Cli.args.isMain:
+        if Cli.args.isMain and not Cli.args.install:
             self.Load()
 
         self.version = Version.string

--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -126,6 +126,7 @@ class Document(object):
         elif result == wx.ID_YES:
             return self.Save()
         else:
+            eg.config.Undo()
             return wx.ID_NO
 
     @eg.LogItWithReturn
@@ -419,6 +420,7 @@ class Document(object):
     def Save(self):
         if not self.filePath:
             return self.SaveAs()
+        eg.config.Save()
         self.WriteFile(self.filePath)
         return wx.ID_YES
 
@@ -426,6 +428,7 @@ class Document(object):
         filePath = self.AskFile(style=wx.SAVE | wx.OVERWRITE_PROMPT)
         if filePath is None:
             return wx.ID_CANCEL
+        eg.config.Save()
         self.WriteFile(filePath)
         self.SetFilePath(filePath)
         return wx.ID_YES

--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -126,7 +126,7 @@ class Document(object):
         elif result == wx.ID_YES:
             return self.Save()
         else:
-            eg.config.Undo()
+            eg.UndoHandler.PersistentData.UndoAll()
             return wx.ID_NO
 
     @eg.LogItWithReturn
@@ -420,7 +420,6 @@ class Document(object):
     def Save(self):
         if not self.filePath:
             return self.SaveAs()
-        eg.config.Save()
         self.WriteFile(self.filePath)
         return wx.ID_YES
 
@@ -428,7 +427,6 @@ class Document(object):
         filePath = self.AskFile(style=wx.SAVE | wx.OVERWRITE_PROMPT)
         if filePath is None:
             return wx.ID_CANCEL
-        eg.config.Save()
         self.WriteFile(filePath)
         self.SetFilePath(filePath)
         return wx.ID_YES
@@ -509,6 +507,7 @@ class Document(object):
             self.SetIsDirty(False)
             self.undoIdOnSave = self.undoId
             success = True
+            eg.config.Save()
         except:
             eg.PrintTraceback("Error while saving file")
         return success

--- a/eg/Classes/PersistentData.py
+++ b/eg/Classes/PersistentData.py
@@ -17,7 +17,139 @@
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
 # Local imports
+
+from types import ClassType
+from StringIO import StringIO
+
 import eg
+from eg.Utils import PrettyPythonPrint
+
+
+class PersistentDataBase(object):
+    _parent = None
+    _key = ''
+
+    def __init__(self, parent, key):
+        self._parent = parent
+        self._key = key
+
+    def IsDelete(self):
+        for key in ('_Delete', '_PermanentDelete'):
+            if self._key.startswith(key):
+                return True
+        return False
+
+    def SetDelete(self, flag=True):
+
+        def SetAttr(key):
+            if key.startswith('_'):
+                attr = self._parent.__dict__.pop(self._key)
+            else:
+                attr = getattr(self._parent, self._key)
+                setattr(self._parent, self._key, None)
+            setattr(attr, '_key', key)
+            setattr(self._parent, key, attr)
+
+        if self._key and not self._key.startswith('_PermanentDelete'):
+            if flag:
+                if not self._key.startswith('_Delete'):
+                    SetAttr('_Delete' + self._key)
+            else:
+                if self._key.startswith('_Delete'):
+                    SetAttr(self._key[7:])
+
+    def SaveData(self, fileWriter, indent):
+        classKeys = []
+
+        for key, value in self:
+            if type(value) in (PersistentDataMeta, PersistentDataBase):
+                classKeys.append([key, value])
+            else:
+                line = PrettyPythonPrint(key, value, indent)
+                fileWriter(line)
+
+        for key, value in classKeys:
+            tmpFile = StringIO()
+
+            value.SaveData(tmpFile.write, indent + 4)
+            data = tmpFile.getvalue()
+            tmpFile.close()
+            if data:
+                formatString = '\n%sclass %s:\n'
+                if not indent and key == 'eg':
+                    formatString = '\n' + formatString
+
+                fileWriter(formatString % (' ' * indent, key))
+                fileWriter(data)
+
+    def GetModuleName(self):
+        moduleName = repr(self._parent).split(' ')[0][1:]
+        if self._key:
+            moduleName += '.' + self._key
+
+        return moduleName
+
+    def __repr__(self):
+        objRepr = object.__repr__(self).split(' ')
+        objRepr[0] = '<' + self.GetModuleName()
+        return ' '.join(objRepr)
+
+    def __delete__(self, instance):
+        if not self._key or self._key.startswith('_PermanentDelete'):
+            return
+
+        if self._key.startswith('_'):
+            attr = getattr(self._parent, self._key)
+            setattr(self._parent, self._key, None)
+            setattr(attr, '_key', self._key[7:])
+        else:
+            attr = self._parent.__dict__.pop(self._key)
+
+        setattr(attr, '_key', '_PermanentDelete' + self._key)
+        setattr(self._parent, getattr(attr, '_key'), attr)
+
+    def __iter__(self):
+        for key in sorted(self.__dict__.keys()):
+            if not key.startswith('_'):
+                yield key, self.__dict__[key]
+
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+    def __getattr__(self, item):
+        if not item.startswith('_'):
+            if item in self.__dict__:
+                return self.__dict__[item]
+            if hasattr(self, '_PermanentDelete' + item):
+                return getattr(self, '_PermanentDelete' + item)
+            if hasattr(self, '_Delete' + item):
+                return getattr(self, '_Delete' + item)
+
+        raise AttributeError(
+            '%s does not have attribute %s' % (self.GetModuleName(), item)
+        )
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+
+    def __setattr__(self, key, value):
+        if key.startswith('_'):
+            object.__setattr__(self, key, value)
+        else:
+            self.__dict__[key] = value
+
+    def __delitem__(self, key):
+        delattr(self, key)
+
+    def __delattr__(self, item):
+        if item.startswith('_'):
+            object.__delattr__(self, item)
+        if item in self.__dict__:
+            del(self.__dict__[item])
+        else:
+            raise AttributeError(
+                '%s does not have attribute %s' % (self.GetModuleName(), item)
+            )
 
 
 class PersistentDataMeta(type):
@@ -28,13 +160,43 @@ class PersistentDataMeta(type):
             config = eg.config
             parts = searchPath.split(".")
 
-            for part in parts[:-1]:
-                config = config.SetDefault(part, eg.Bunch)
+            plugin = False
+            for part in parts:
+                if hasattr(config, part):
+                    config = getattr(config, part)
+                else:
+                    newConfig = PersistentDataBase(config, part)
+                    setattr(config, part, newConfig)
+                    config = newConfig
 
-            if eg.debugLevel and hasattr(config, parts[-1]):
-                eg.config.AddDebugData('.'.join(parts))
+                    if plugin:
+                        if part in ('EventGhost', 'Window', 'System', 'Mouse'):
+                            plugin = False
+                        else:
+                            config.SetDelete(True)
 
-            return config.SetDefault(parts[-1], cls)
+                if part in ('CorePluginModule', 'UserPluginModule'):
+                    plugin = True
+
+            def IterDict(c, d):
+                for k in d.keys():
+                    if k.startswith('_'):
+                        continue
+                    v = d[k]
+                    if isinstance(v, ClassType):
+                        if hasattr(c, k):
+                            configCls = getattr(c, k)
+                        else:
+                            configCls = PersistentDataBase(c, k)
+                        IterDict(configCls, v.__dict__)
+                        setattr(c, k, configCls)
+                    else:
+                        if not hasattr(c, k):
+                            setattr(c, k, v)
+            IterDict(config, cls.__dict__)
+
+            return config
+
         return cls
 
 

--- a/eg/Classes/PersistentData.py
+++ b/eg/Classes/PersistentData.py
@@ -19,6 +19,7 @@
 # Local imports
 import eg
 
+
 class PersistentDataMeta(type):
     def __new__(mcs, name, bases, dct):
         cls = type.__new__(mcs, name, bases, dct)
@@ -26,8 +27,13 @@ class PersistentDataMeta(type):
             searchPath = dct["__module__"]
             config = eg.config
             parts = searchPath.split(".")
+
             for part in parts[:-1]:
                 config = config.SetDefault(part, eg.Bunch)
+
+            if eg.debugLevel and hasattr(config, parts[-1]):
+                eg.config.AddDebugData('.'.join(parts))
+
             return config.SetDefault(parts[-1], cls)
         return cls
 

--- a/eg/Classes/PluginItem.py
+++ b/eg/Classes/PluginItem.py
@@ -60,21 +60,6 @@ class PluginItem(ActionItem):
     def AskCut(self):
         return self.AskDelete()
 
-    def GetPersistantData(self):
-        info = self.info
-        if info.path.startswith(eg.corePluginDir):
-            configName = "CorePluginModule"
-        else:
-            configName = "UserPluginModule"
-
-        if hasattr(eg.config.eg, configName):
-            config = getattr(eg.config.eg, configName)
-        else:
-            config = None
-
-        if config and hasattr(config, info.pluginName):
-            return 'eg.%s.%s' % (configName, info.pluginName)
-
     def AskDelete(self):
         actionItemCls = self.document.ActionItem
 
@@ -94,16 +79,15 @@ class PluginItem(ActionItem):
         if not TreeItem.AskDelete(self):
             return False
 
-        config = self.GetPersistantData()
-
-        if config:
+        if self.info.persistentData.config:
             answer = eg.MessageBox(
                 eg.text.General.deleteConfigMessage,
                 eg.text.General.deleteConfigCaption,
                 wx.YES_NO | wx.ICON_QUESTION
             )
             if answer == wx.ID_YES:
-                eg.config.MarkForDelete(config)
+                self.info.persistentData.Delete(True)
+
         return True
 
     @eg.AssertInActionThread
@@ -114,7 +98,6 @@ class PluginItem(ActionItem):
             info.Close()
             info.instance.OnDelete()
             info.RemovePluginInstance()
-
         eg.actionThread.Call(DoIt)
 
         ActionItem.Delete(self)
@@ -175,10 +158,6 @@ class PluginItem(ActionItem):
         """
         # if the Configure method of the executable is overriden, we assume
         # the item wants to be configured after creation
-        config = self.GetPersistantData()
-        if config:
-            eg.config.AddUndoData(config)
-
         return (
             self.executable.Configure.im_func !=
             eg.PluginBase.Configure.im_func

--- a/eg/Classes/PluginItem.py
+++ b/eg/Classes/PluginItem.py
@@ -81,7 +81,7 @@ class PluginItem(ActionItem):
 
         if self.info.persistentData.config:
             answer = eg.MessageBox(
-                eg.text.General.deleteConfigMessage,
+                eg.text.General.deleteConfigMessage % self.info.name,
                 eg.text.General.deleteConfigCaption,
                 wx.YES_NO | wx.ICON_QUESTION
             )

--- a/eg/Classes/Text.py
+++ b/eg/Classes/Text.py
@@ -24,6 +24,8 @@ from eg.Utils import SetDefault
 
 class Default:
     class General:
+        deleteConfigMessage = "Do you want to remove all configuration data?"
+        deleteConfigCaption = "Delete Configuration Data"
         configTree = "Configuration Tree"
         deleteQuestion = "Are you sure you want to delete this item?"
         deleteManyQuestion = (

--- a/eg/Classes/Text.py
+++ b/eg/Classes/Text.py
@@ -24,7 +24,10 @@ from eg.Utils import SetDefault
 
 class Default:
     class General:
-        deleteConfigMessage = "Do you want to remove all configuration data?"
+        deleteConfigMessage = (
+            "Do you want to remove all configuration data\n"
+            "for plugin %s?\n\n"
+        )
         deleteConfigCaption = "Delete Configuration Data"
         configTree = "Configuration Tree"
         deleteQuestion = "Are you sure you want to delete this item?"

--- a/eg/Classes/UndoHandler/NewPlugin.py
+++ b/eg/Classes/UndoHandler/NewPlugin.py
@@ -40,6 +40,7 @@ class NewPlugin(NewItem):
         if pluginItem.executable:
             if pluginItem.NeedsStartupConfiguration():
                 if not eg.UndoHandler.Configure(document).Do(pluginItem, True):
+                    pluginItem.info.persistentData.Remove()
                     eg.actionThread.Call(pluginItem.Delete)
                     return None
             eg.actionThread.Call(pluginItem.Execute)

--- a/eg/Classes/UndoHandler/PersistentData.py
+++ b/eg/Classes/UndoHandler/PersistentData.py
@@ -27,14 +27,10 @@ class PersistentData(UndoHandlerBase):
         UndoHandlerBase.__init__(self, None)
         self.__class__._UndoHandlers.append(self)
         self.config = config
-        self.flag = False
+        self.flag = Falses
+        self.Redo = self.Undo
         if config:
             config.SetDelete(False)
-
-    def Redo(self):
-        if self.config:
-            self.flag = not self.flag
-            self.config.SetDelete(self.flag)
 
     def Undo(self):
         if self.config:

--- a/eg/Classes/UndoHandler/PersistentData.py
+++ b/eg/Classes/UndoHandler/PersistentData.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.net/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+
+from eg.Classes.UndoHandler import UndoHandlerBase
+
+
+class PersistentData(UndoHandlerBase):
+    _UndoHandlers = []
+
+    def __init__(self, config):
+        UndoHandlerBase.__init__(self, None)
+        self.__class__._UndoHandlers.append(self)
+        self.config = config
+        self.flag = False
+        if config:
+            config.SetDelete(False)
+
+    def Redo(self):
+        if self.config:
+            self.flag = not self.flag
+            self.config.SetDelete(self.flag)
+
+    def Undo(self):
+        if self.config:
+            self.flag = not self.flag
+            self.config.SetDelete(self.flag)
+
+    def Delete(self, flag):
+        self.flag = flag
+        if self.config:
+            self.config.SetDelete(flag)
+
+    def Remove(self):
+        if self.config:
+            del(self.config)
+        self.__class__._UndoHandlers.remove(self)
+
+    @classmethod
+    def UndoAll(cls):
+        for handler in cls._UndoHandlers:
+            handler.Undo()
+

--- a/eg/Classes/UndoHandler/PersistentData.py
+++ b/eg/Classes/UndoHandler/PersistentData.py
@@ -27,7 +27,7 @@ class PersistentData(UndoHandlerBase):
         UndoHandlerBase.__init__(self, None)
         self.__class__._UndoHandlers.append(self)
         self.config = config
-        self.flag = Falses
+        self.flag = False
         self.Redo = self.Undo
         if config:
             config.SetDelete(False)

--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -26,6 +26,8 @@ import os
 import pywintypes
 import sys
 from os.path import abspath, dirname, join
+from Classes.FolderPath import FolderPath
+
 
 ENCODING = locale.getdefaultlocale()[1]
 locale.setlocale(locale.LC_ALL, '')
@@ -34,6 +36,8 @@ scriptPath = argvIter.next()
 
 # get program directory
 mainDir = abspath(join(dirname(__file__.decode('mbcs')), ".."))
+# get config directory
+configDir = join(FolderPath().RoamingAppData, 'EventGhost')
 
 # determine the commandline parameters
 import __main__  # NOQA
@@ -41,7 +45,7 @@ import __main__  # NOQA
 
 class args:
     allowMultiLoad = False
-    configDir = None
+    configDir = configDir
     debugLevel = 0
     hideOnStartup = False
     install = False
@@ -50,7 +54,6 @@ class args:
     startupEvent = None
     startupFile = None
     translate = False
-
 
 if args.isMain:
     for arg in argvIter:

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -46,6 +46,9 @@ from os.path import exists, join
 import eg
 import Init
 
+eg.config = eg.Config()
+eg.debugLevel = int(eg.Cli.args.debugLevel or eg.config.logDebug)
+
 eg.APP_NAME = "EventGhost"
 eg.CORE_PLUGIN_GUIDS = (
     "{9D499A2C-72B6-40B0-8C8C-995831B10BB4}",  # "EventGhost"
@@ -64,7 +67,6 @@ eg.sitePackagesDir = join(
 )
 eg.revision = 2000  # Deprecated
 eg.startupArguments = eg.Cli.args
-eg.debugLevel = eg.startupArguments.debugLevel
 eg.systemEncoding = locale.getdefaultlocale()[1]
 eg.document = None
 eg.result = None
@@ -361,8 +363,6 @@ eg.PrintTraceback = eg.log.PrintTraceback
 eg.PrintDebugNotice = eg.log.PrintDebugNotice
 eg.PrintStack = eg.log.PrintStack
 
-eg.config = eg.Config()
-eg.debugLevel = int(eg.config.logDebug) or eg.debugLevel
 
 def TracebackHook(tType, tValue, traceback):
     eg.log.PrintTraceback(excInfo=(tType, tValue, traceback))

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -38,7 +38,7 @@ __all__ = [
     "Bunch", "NotificationHandler", "LogIt", "LogItWithReturn", "TimeIt",
     "AssertInMainThread", "AssertInActionThread", "ParseString", "SetDefault",
     "EnsureVisible", "VBoxSizer", "HBoxSizer", "EqualizeWidths", "AsTasklet",
-    "ExecFile", "GetTopLevelWindow",
+    "ExecFile", "GetTopLevelWindow", "PrettyPythonPrint"
 ]
 
 USER_CLASSES = (type, ClassType)
@@ -90,6 +90,46 @@ class MyHtmlDocWriter(Writer):
 """ % self.interpolation_dict()
 
 HTML_DOC_WRITER = MyHtmlDocWriter()
+
+
+def PrettyPythonPrint(attrName, attrValue, indent):
+    if isinstance(indent, basestring):
+        indt = (len(indent))
+        if indent.find('\t') > -1:
+            indt *= 4
+        indent = indt
+
+    indent4 = ' ' * (indent + 4)
+    indent = ' ' * indent
+    line = '%s%s = ' % (indent, attrName)
+
+    multiLine = len(line + repr(attrValue)) > 76
+
+    if multiLine and type(attrValue) in (unicode, str, list, tuple):
+        if type(attrValue) == list:
+            line += '[\n'
+            for item in attrValue:
+                line += '%s%r,\n' % (indent4, item)
+            line = '%s\n%s]' % (line[:-2], indent)
+
+        else:
+            if type(attrValue) in (unicode, str):
+                stop = 76 - len(indent4)
+                if stop > 25:
+                    line += '(\n'
+                    while len(repr(attrValue) + indent4) > 76:
+                        line += '%s%r\n' % (indent4, attrValue[:stop])
+                        attrValue = attrValue[stop:]
+                    line += '%s%r\n%s)' % (indent4, attrValue, indent)
+                else:
+                    line += repr(attrValue)
+            else:
+                for item in attrValue:
+                    line += '%s%r,\n' % (indent4, item)
+                line = '%s\n%s)' % (line[:-2], indent)
+    else:
+        line += repr(attrValue)
+    return line + '\n'
 
 
 class NotificationHandler(object):

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -150,11 +150,9 @@ def PrettyPythonPrint(attrName, attrValue, indent):
         line += AddBracket(True, attrValue, 0) + '\n'
         line += IterValue(attrValue, indent + 4)
         line = line[:-2] + '\n' + AddBracket(False, attrValue, indent) + '\n'
-
     else:
-        eg.PrintDebugNotice(repr(attrValue))
         line += '%r\n' % (attrValue,)
-
+        
     return line
 
 

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -93,43 +93,69 @@ HTML_DOC_WRITER = MyHtmlDocWriter()
 
 
 def PrettyPythonPrint(attrName, attrValue, indent):
-    if isinstance(indent, basestring):
+    types = (dict, list, tuple, unicode, str)
+
+    if type(indent) in types[3:]:
         indt = (len(indent))
         if indent.find('\t') > -1:
             indt *= 4
         indent = indt
 
-    indent4 = ' ' * (indent + 4)
-    indent = ' ' * indent
-    line = '%s%s = ' % (indent, attrName)
-
+    line = '%s%s = ' % (' ' * indent, attrName)
     multiLine = len(line + repr(attrValue)) > 76
+    jump = 71 - indent
 
-    if multiLine and type(attrValue) in (unicode, str, list, tuple):
-        if type(attrValue) == list:
-            line += '[\n'
-            for item in attrValue:
-                line += '%s%r,\n' % (indent4, item)
-            line = '%s\n%s]' % (line[:-2], indent)
-
+    def AddBracket(open, value, idt):
+        if type(value) == list:
+            bracket = '[]'
+        elif type(value) == dict:
+            bracket = '{}'
         else:
-            if type(attrValue) in (unicode, str):
-                stop = 76 - len(indent4)
-                if stop > 25:
-                    line += '(\n'
-                    while len(repr(attrValue) + indent4) > 76:
-                        line += '%s%r\n' % (indent4, attrValue[:stop])
-                        attrValue = attrValue[stop:]
-                    line += '%s%r\n%s)' % (indent4, attrValue, indent)
-                else:
-                    line += repr(attrValue)
-            else:
-                for item in attrValue:
-                    line += '%s%r,\n' % (indent4, item)
-                line = '%s\n%s)' % (line[:-2], indent)
+            bracket = '()'
+        idt = ' ' * idt
+        return idt + bracket[:1] if open else idt + bracket[1:]
+
+    def IterValue(value, idt):
+        def CheckItem(item):
+            if type(item) in types[:3] and len(' ' * idt + repr(item)) > 76:
+                newLine = AddBracket(True, item, idt) + '\n'
+                newLine += IterValue(item, idt + 4)
+                newLine += AddBracket(False, item, idt) + ',\n'
+                return newLine
+            return '%s%r,\n' % (' ' * idt, item)
+
+        ln = ''
+
+        if type(value) == dict:
+            for k in sorted(value.keys()):
+                ln += (
+                    '%s%r: %s' %
+                    (' ' * idt, k, CheckItem(value[k])[idt:])
+                )
+        else:
+            for item in value:
+                ln += CheckItem(item)
+
+        return ln
+
+    if type(attrValue) in types and multiLine and jump > 20:
+        if type(attrValue) in types[2:]:
+            newAttrValue = ()
+            while attrValue:
+                jump = min([len(attrValue), jump])
+                newAttrValue += (attrValue[:jump],)
+                attrValue = attrValue[jump:]
+            attrValue = newAttrValue
+
+        line += AddBracket(True, attrValue, 0) + '\n'
+        line += IterValue(attrValue, indent + 4)
+        line = line[:-2] + '\n' + AddBracket(False, attrValue, indent) + '\n'
+
     else:
-        line += repr(attrValue)
-    return line + '\n'
+        eg.PrintDebugNotice(repr(attrValue))
+        line += '%r\n' % (attrValue,)
+
+    return line
 
 
 class NotificationHandler(object):


### PR DESCRIPTION
When removing a plugin eg.config is scanned for any eg.PersistantData the plugin may have set. and if it finds any prompts the user if they would like to delete this data. If yes the data is marked for deletion. If the user does not save their EventGhost session all of the marks for deletion are removed. It also handles the ImportAll() when the debug level is set from a command line.