### PR TITLE
[EventGhost] - Enhancement - MainFrame. On application exit closes open dialogs if no unsaved data

### DIFF
--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -580,20 +580,19 @@ class MainFrame(wx.Frame):
         elif len(self.openDialogs) == 0:
             eg.app.Exit()
         else:
+            for dialog in self.openDialogs[:]:
                 panel = getattr(dialog, 'panel', None)
-                    if not panel.isDirty:
                 try:
+                    if not panel.isDirty:
                         dialog.Destroy()
                         continue
-                    pass
                 except AttributeError:
-                self.Iconize(False)
-            for dialog in self.openDialogs[:]:
+                    pass
 
+                self.Iconize(False)
                 dialog.Raise()
                 self.RequestUserAttention()
                 return
-
             self.OnClose(None)
 
     @eg.LogIt

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -545,29 +545,20 @@ class MainFrame(wx.Frame):
             else:
                 eg.app.Exit()
         else:
-            dialogNames = []
-            for dialog in self.openDialogs:
-                dialogName = dialog.GetTitle() + ' - '
-                if hasattr(dialog, 'headerBox'):
-                    dialogName += dialog.headerBox.GetChildren()[0].GetLabel()
-                else:
-                    dialogName = dialogName[:-3]
-                dialogNames.append(dialogName)
-            message = (
-                eg.text.General.closeOpenDialogMessage +
-                '\n'.join(dialogNames)
-            )
-            answer = eg.MessageBox(
-                message,
-                eg.text.General.closeOpenDialogCaption,
-                style=wx.YES_NO | wx.ICON_QUESTION
-            )
-            if answer == wx.ID_YES:
-                for dialog in self.openDialogs[:]:
-                    dialog.Destroy()
-                self.OnClose(None)
-            else:
+            for dialog in self.openDialogs[:]:
+                panel = getattr(dialog, 'panel', None)
+                try:
+                    if not panel.isDirty:
+                        dialog.Destroy()
+                        continue
+                except AttributeError:
+                    pass
+
+                dialog.Raise()
                 self.RequestUserAttention()
+                return
+
+            self.OnClose(None)
 
     @eg.LogIt
     def OnDialogDestroy(self, event):

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -545,7 +545,29 @@ class MainFrame(wx.Frame):
             else:
                 eg.app.Exit()
         else:
-            self.RequestUserAttention()
+            dialogNames = []
+            for dialog in self.openDialogs:
+                dialogName = dialog.GetTitle() + ' - '
+                if hasattr(dialog, 'headerBox'):
+                    dialogName += dialog.headerBox.GetChildren()[0].GetLabel()
+                else:
+                    dialogName = dialogName[:-3]
+                dialogNames.append(dialogName)
+            message = (
+                eg.text.General.closeOpenDialogMessage +
+                '\n'.join(dialogNames)
+            )
+            answer = eg.MessageBox(
+                message,
+                eg.text.General.closeOpenDialogCaption,
+                style=wx.YES_NO | wx.ICON_QUESTION
+            )
+            if answer == wx.ID_YES:
+                for dialog in self.openDialogs[:]:
+                    dialog.Destroy()
+                self.OnClose(None)
+            else:
+                self.RequestUserAttention()
 
     @eg.LogIt
     def OnDialogDestroy(self, event):

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -580,8 +580,18 @@ class MainFrame(wx.Frame):
         elif len(self.openDialogs) == 0:
             eg.app.Exit()
         else:
-            self.Iconize(False)
-            self.RequestUserAttention()
+            for dialog in self.openDialogs[:]:
+                panel = getattr(dialog, 'panel', None)
+                try:
+                    if not panel.isDirty:
+                        dialog.Destroy()
+                        continue
+                except AttributeError:
+                    pass
+                self.Iconize(False)
+                dialog.Raise()
+                self.RequestUserAttention()
+                return
 
     @eg.LogIt
     def OnDialogDestroy(self, event):
@@ -843,7 +853,7 @@ class MainFrame(wx.Frame):
         eg.OptionsDialog.GetResult(self)
 
     def OnCmdRestart(self):
-        eg.app.Restart()
+        eg.Utils.Restart(save=False, closeDialogs=True)
 
     def OnCmdExit(self):
         eg.app.Exit()

--- a/eg/Classes/Text.py
+++ b/eg/Classes/Text.py
@@ -24,11 +24,6 @@ from eg.Utils import SetDefault
 
 class Default:
     class General:
-        closeOpenDialogMessage = (
-            "There are open dialogs would you like\n"
-            "to close them?\n\n"
-        )
-        closeOpenDialogCaption = "Close open dialogs"
         configTree = "Configuration Tree"
         deleteQuestion = "Are you sure you want to delete this item?"
         deleteManyQuestion = (

--- a/eg/Classes/Text.py
+++ b/eg/Classes/Text.py
@@ -24,6 +24,11 @@ from eg.Utils import SetDefault
 
 class Default:
     class General:
+        closeOpenDialogMessage = (
+            "There are open dialogs would you like\n"
+            "to close them?\n\n"
+        )
+        closeOpenDialogCaption = "Close open dialogs"
         configTree = "Configuration Tree"
         deleteQuestion = "Are you sure you want to delete this item?"
         deleteManyQuestion = (


### PR DESCRIPTION
When closing EventGhost instead of just having it blink at you if there is a dialog still open this will list all of the open dialogs and ask if you want to close them.

This solves a large inconvenience when creating a plugin and debugging a configuration panel that throws a traceback and offers no way to close it resulting in the developer having to end the process.