### PR TITLE
Change how the MainFrame handles Id's

### DIFF
--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -40,23 +40,21 @@ ADD_MACRO_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.MACRO_ICON)
 ADD_EVENT_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.EVENT_ICON)
 ADD_ACTION_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.ACTION_ICON)
 
-ID_DISABLED = wx.NewId()
-ID_EXECUTE = wx.NewId()
-ID_PYTHON = wx.NewId()
-ID_TOOLBAR_EXECUTE = wx.NewId()
+class ID(dict):
+    def __getitem__(self, item):
+        return getattr(self, item.upper())
 
-ID = defaultdict(wx.NewId, {
-    "Save": wx.ID_SAVE,
-    "Undo": wx.ID_UNDO,
-    "Redo": wx.ID_REDO,
-    "Cut": wx.ID_CUT,
-    "Copy": wx.ID_COPY,
-    "Python": ID_PYTHON,
-    "Paste": wx.ID_PASTE,
-    "Delete": wx.ID_DELETE,
-    "Disabled": ID_DISABLED,
-    "Execute": ID_EXECUTE,
-})
+    def __getattr__(self, item):
+        item = item.upper()
+        if hasattr(wx, 'ID_' + item.upper()):
+            attr = getattr(wx, 'ID_' + item.upper())
+        else:
+            attr = wx.NewId()
+        setattr(self, item, attr)
+        return attr
+
+ID = ID()
+
 
 Text = eg.text.MainFrame
 
@@ -396,12 +394,12 @@ class MainFrame(wx.Frame):
         # the menu command OnCmdExecute will be used in conjunction to
         # our special mouse click handlers
         toolBar.AddSimpleTool(
-            ID_TOOLBAR_EXECUTE,
+            ID.TOOLBAR_EXECUTE,
             GetInternalBitmap("Execute"),
             getattr(text, "Execute")
         )
 
-        toolBar.EnableTool(wx.ID_SAVE, self.document.isDirty)
+        toolBar.EnableTool(ID.SAVE, self.document.isDirty)
         toolBar.Realize()
         self.SetToolBar(toolBar)
 
@@ -532,7 +530,7 @@ class MainFrame(wx.Frame):
     def OnClipboardChange(self, dummyValue):
         if self.lastFocus == self.treeCtrl:
             canPaste = self.treeCtrl.GetSelectedNode().CanPaste()
-            self.toolBar.EnableTool(wx.ID_PASTE, canPaste)
+            self.toolBar.EnableTool(ID.PASTE, canPaste)
 
     @eg.LogIt
     def OnClose(self, dummyEvent):
@@ -558,8 +556,8 @@ class MainFrame(wx.Frame):
             self.SetWindowStyleFlag(self.style)
 
     def OnDocumentChange(self, isDirty):
-        wx.CallAfter(self.toolBar.EnableTool, wx.ID_SAVE, bool(isDirty))
-        wx.CallAfter(self.menuBar.Enable, wx.ID_SAVE, bool(isDirty))
+        wx.CallAfter(self.toolBar.EnableTool, ID.SAVE, bool(isDirty))
+        wx.CallAfter(self.menuBar.Enable, ID.SAVE, bool(isDirty))
 
     def OnDocumentFileChange(self, filepath):
         self.SetTitle(self.document.GetTitle())
@@ -580,10 +578,10 @@ class MainFrame(wx.Frame):
         self.lastFocus = focus
         toolBar = self.toolBar
         canCut, canCopy, canPython, canPaste = self.GetEditCmdState()[:4]
-        toolBar.EnableTool(wx.ID_CUT, canCut)
-        toolBar.EnableTool(wx.ID_COPY, canCopy)
-        toolBar.EnableTool(ID_PYTHON, canPython)
-        toolBar.EnableTool(wx.ID_PASTE, canPaste)
+        toolBar.EnableTool(ID.CUT, canCut)
+        toolBar.EnableTool(ID.COPY, canCopy)
+        toolBar.EnableTool(ID.PYTHON, canPython)
+        toolBar.EnableTool(ID.PASTE, canPaste)
 
     @eg.LogIt
     def OnIconize(self, dummyEvent):
@@ -647,10 +645,10 @@ class MainFrame(wx.Frame):
 
     def OnSelectionChange(self, dummySelection):
         canCut, canCopy, canPython, canPaste = self.GetEditCmdState()[:4]
-        self.toolBar.EnableTool(wx.ID_CUT, canCut)
-        self.toolBar.EnableTool(wx.ID_COPY, canCopy)
-        self.toolBar.EnableTool(ID_PYTHON, canPython)
-        self.toolBar.EnableTool(wx.ID_PASTE, canPaste)
+        self.toolBar.EnableTool(ID.CUT, canCut)
+        self.toolBar.EnableTool(ID.COPY, canCopy)
+        self.toolBar.EnableTool(ID.PYTHON, canPython)
+        self.toolBar.EnableTool(ID.PASTE, canPaste)
 
     def OnSize(self, event):
         """
@@ -667,7 +665,7 @@ class MainFrame(wx.Frame):
         """
         x, y = event.GetPosition()
         item = self.toolBar.FindToolForPosition(x, y)
-        if item and item.GetId() == ID_TOOLBAR_EXECUTE:
+        if item and item.GetId() == ID.TOOLBAR_EXECUTE:
             node = self.treeCtrl.GetSelectedNode()
             if not node.isExecutable:
                 self.DisplayError(Text.Messages.cantExecute)
@@ -691,20 +689,20 @@ class MainFrame(wx.Frame):
         undoName = Text.Menu.Undo + undoName
         redoName = Text.Menu.Redo + redoName
 
-        self.menuBar.Enable(wx.ID_UNDO, hasUndos)
-        self.menuBar.SetLabel(wx.ID_UNDO, undoName + "\tCtrl+Z")
-        self.menuBar.Enable(wx.ID_REDO, hasRedos)
-        self.menuBar.SetLabel(wx.ID_REDO, redoName + "\tCtrl+Y")
+        self.menuBar.Enable(ID.UNDO, hasUndos)
+        self.menuBar.SetLabel(ID.UNDO, undoName + "\tCtrl+Z")
+        self.menuBar.Enable(ID.REDO, hasRedos)
+        self.menuBar.SetLabel(ID.REDO, redoName + "\tCtrl+Y")
 
-        self.popupMenu.Enable(wx.ID_UNDO, hasUndos)
-        self.popupMenu.SetLabel(wx.ID_UNDO, undoName)
-        self.popupMenu.Enable(wx.ID_REDO, hasRedos)
-        self.popupMenu.SetLabel(wx.ID_REDO, redoName)
+        self.popupMenu.Enable(ID.UNDO, hasUndos)
+        self.popupMenu.SetLabel(ID.UNDO, undoName)
+        self.popupMenu.Enable(ID.REDO, hasRedos)
+        self.popupMenu.SetLabel(ID.REDO, redoName)
 
-        self.toolBar.EnableTool(wx.ID_UNDO, hasUndos)
-        self.toolBar.SetToolShortHelp(wx.ID_UNDO, undoName)
-        self.toolBar.EnableTool(wx.ID_REDO, hasRedos)
-        self.toolBar.SetToolShortHelp(wx.ID_REDO, redoName)
+        self.toolBar.EnableTool(ID.UNDO, hasUndos)
+        self.toolBar.SetToolShortHelp(ID.UNDO, undoName)
+        self.toolBar.EnableTool(ID.REDO, hasRedos)
+        self.toolBar.SetToolShortHelp(ID.REDO, redoName)
 
     def Raise(self):
         BringHwndToFront(self.GetHandle())
@@ -712,13 +710,13 @@ class MainFrame(wx.Frame):
 
     def SetupEditMenu(self, menu):
         canCut, canCopy, canPython, canPaste, canDelete = self.GetEditCmdState()
-        menu.Enable(wx.ID_CUT, canCut)
-        menu.Enable(wx.ID_COPY, canCopy)
-        menu.Enable(ID_PYTHON, canPython)
-        menu.Enable(wx.ID_PASTE, canPaste)
-        menu.Enable(wx.ID_DELETE, canDelete)
+        menu.Enable(ID.CUT, canCut)
+        menu.Enable(ID.COPY, canCopy)
+        menu.Enable(ID.PYTHON, canPython)
+        menu.Enable(ID.PASTE, canPaste)
+        menu.Enable(ID.DELETE, canDelete)
         selection = self.treeCtrl.GetSelectedNode()
-        menu.Check(ID_DISABLED, selection is not None and not selection.isEnabled)
+        menu.Check(ID.DISABLED, selection is not None and not selection.isEnabled)
 
     def UpdateRatio(self):
         self.logCtrl.SetColumnWidth(

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -25,6 +25,7 @@ from os.path import join
 
 # Local imports
 import eg
+from eg.Classes import WXIdManager as ID
 from eg.Classes.MainFrame.LogCtrl import LogCtrl
 from eg.Classes.MainFrame.StatusBar import StatusBar
 from eg.Classes.MainFrame.TreeCtrl import TreeCtrl
@@ -38,22 +39,6 @@ ADD_FOLDER_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.FOLDER_ICON)
 ADD_MACRO_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.MACRO_ICON)
 ADD_EVENT_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.EVENT_ICON)
 ADD_ACTION_ICON = CreateBitmapOnTopOfIcon(ADD_ICON, eg.Icons.ACTION_ICON)
-
-class ID(dict):
-    def __getitem__(self, item):
-        return getattr(self, item.upper())
-
-    def __getattr__(self, item):
-        item = item.upper()
-        if hasattr(wx, 'ID_' + item.upper()):
-            attr = getattr(wx, 'ID_' + item.upper())
-        else:
-            attr = wx.NewId()
-        setattr(self, item, attr)
-        return attr
-
-ID = ID()
-
 
 Text = eg.text.MainFrame
 

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -21,7 +21,6 @@ import re
 import types
 import wx
 import wx.aui
-from collections import defaultdict
 from os.path import join
 
 # Local imports

--- a/eg/Classes/WXIdManager.py
+++ b/eg/Classes/WXIdManager.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.org/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+import wx
+import sys
+
+
+class WXIdManager(object):
+    """
+    Convenience class for wxID's.
+
+    This is an attribute only class. If the attribute name exists in wx as an
+    id it will collect that id and set it into this class and return it. If it
+    does not exist this class will generate a wxNewId and and set it then
+    return it. Every time the same attribute name is used it will always
+    return the same id.
+
+    Example:
+        widgetId = eg.WXIdManager.OK
+            The above will grab the wx.ID_OK and return it.
+
+        widgetId = eg.WXIdManager.SOME_ID
+            The above will generate a new wxId and return it.
+    """
+    def __init__(self):
+        self.__dict__ = sys.modules[__name__].__dict__
+        self.__originalmodule__ = sys.modules[__name__]
+        sys.modules[__name__] = self
+        sys.modules[__name__ + '.' + __name__.split('.')[-1]] = self
+
+    def __getitem__(self, item):
+        return getattr(self, item.upper())
+
+    def __getattr__(self, item):
+        if item.startswith('_'):
+            if item in self.__dict__:
+                return self.__dict__[item]
+            raise AttributeError(
+                '%r does not have attribute %s' % (self, item)
+            )
+
+        item = item.upper()
+        if hasattr(wx, 'ID_' + item):
+            attr = getattr(wx, 'ID_' + item)
+        else:
+            attr = wx.NewId()
+        setattr(self, item, attr)
+        return attr
+
+WXIdManager = WXIdManager()


### PR DESCRIPTION
Replaced use of collections.defaultdict with a custom class that checks wx to see if the attribute being asked for exists. If it does gets the attribute from wx and sets it as an attribute of the class ID. This also allows for getting ID's in a dictionary fashion ID['ID_NAME'] or ID.ID_NAME.
Removed collections.defaultdict import
Re-pointed all  wx.ID_ items to ID.