### PR TITLE
Not being able to restore from a minimized state if tray icon is not shown and empty log

### DIFF
--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -300,8 +300,8 @@ class Document(object):
         if self.reentrantLock.acquire(False):
             if self.frame is not None:
                 if len(self.frame.openDialogs) == 0:
-                    self.frame.Destroy()
-                    self.frame = None
+                    self.frame.Hide()
+                    # self.frame = None
             self.reentrantLock.release()
         else:
             wx.CallLater(100, self.HideFrame)

--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -298,10 +298,8 @@ class Document(object):
         # TODO: Find a better way. Preferable detect the minimize option
         #       before we create the MainFrame.
         if self.reentrantLock.acquire(False):
-            if self.frame is not None:
-                if len(self.frame.openDialogs) == 0:
-                    self.frame.Hide()
-                    # self.frame = None
+            if len(self.frame.openDialogs) == 0:
+                self.frame.Hide()
             self.reentrantLock.release()
         else:
             wx.CallLater(100, self.HideFrame)

--- a/eg/Classes/MainFrame/LogCtrl.py
+++ b/eg/Classes/MainFrame/LogCtrl.py
@@ -111,6 +111,7 @@ class LogCtrl(wx.ListCtrl):
         self.isOdd = False
         self.data = collections.deque()
         eg.log.SetCtrl(self)
+        wx.CallAfter(self.SetData, eg.log.GetData())
 
     if eg.debugLevel:
         @eg.LogIt

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -541,7 +541,11 @@ class MainFrame(wx.Frame):
         """
         if len(self.openDialogs) == 0:
             if eg.config.hideOnClose:
-                self.document.HideFrame()
+                if eg.config.showTrayIcon:
+                    self.document.HideFrame()
+                else:
+                    self.Iconize()
+
             else:
                 eg.app.Exit()
         else:
@@ -590,7 +594,6 @@ class MainFrame(wx.Frame):
         """
         Handle wx.EVT_ICONIZE
         """
-        # On iconizing, we actually destroy the frame completely
         if eg.config.showTrayIcon:
             self.document.HideFrame()
         else:

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -227,10 +227,11 @@ class MainFrame(wx.Frame):
         self.SetAcceleratorTable(self.acceleratorTable)
         self.logCtrl.Bind(wx.EVT_SIZE, self.OnLogCtrlSize)
 
-        if eg.config.hideOnStartup or eg.startupArguments.hideOnStartup:
-            self.Iconize(True)
-        else:
+        if not(eg.config.hideOnStartup or eg.startupArguments.hideOnStartup):
+            self.Show()
             eg.EnsureVisible(self)
+        else:
+            self.Iconize(True)
 
     if eg.debugLevel:
         @eg.LogIt
@@ -603,7 +604,6 @@ class MainFrame(wx.Frame):
 
     def OnIconize(self, event):
         self.Iconize(event.Iconized())
-
 
     def OnLogCtrlSize(self, evt):
         if self.mainSizeFlag:

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -227,11 +227,7 @@ class MainFrame(wx.Frame):
         self.SetAcceleratorTable(self.acceleratorTable)
         self.logCtrl.Bind(wx.EVT_SIZE, self.OnLogCtrlSize)
 
-        if not(eg.config.hideOnStartup or eg.startupArguments.hideOnStartup):
-            self.Show()
-            eg.EnsureVisible(self)
-        else:
-            self.Iconize(True)
+        eg.EnsureVisible(self)
 
     if eg.debugLevel:
         @eg.LogIt
@@ -592,14 +588,12 @@ class MainFrame(wx.Frame):
 
     @eg.LogIt
     def Iconize(self, flag=True):
-        wx.Frame.Iconize(self, flag)
         if eg.config.showTrayIcon:
-            self.Show(not flag)
+            self.document.HideFrame()
+        else:
+            wx.Frame.Iconize(self, flag)
 
-        for dialog in self.openDialogs:
-            if eg.config.showTrayIcon:
-                dialog.Show(not flag)
-            else:
+            for dialog in self.openDialogs:
                 dialog.Iconize(flag)
 
     def OnIconize(self, event):

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -588,7 +588,7 @@ class MainFrame(wx.Frame):
 
     @eg.LogIt
     def Iconize(self, flag=True):
-        if eg.config.showTrayIcon:
+        if flag and eg.config.showTrayIcon:
             self.document.HideFrame()
         else:
             wx.Frame.Iconize(self, flag)

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -525,8 +525,8 @@ class MainFrame(wx.Frame):
         """
         Changes the main frame style depending on the display of the tray icon.
 
-        Sets the stlye flags fo the minimize button will be grayed out if the
-        tray icon is shown and there are any open child windows.
+        Sets the style flags for the minimize button. It will be grayed out if
+        the tray icon is shown and there child dialogs open.
         If the tray icon is not shown the minimize button will function as
         usual.
 

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -586,12 +586,15 @@ class MainFrame(wx.Frame):
         toolBar.EnableTool(wx.ID_PASTE, canPaste)
 
     @eg.LogIt
-    def OnIconize(self, dummyEvent):
+    def OnIconize(self, event):
         """
         Handle wx.EVT_ICONIZE
         """
         # On iconizing, we actually destroy the frame completely
-        self.document.HideFrame()
+        if eg.config.showTrayIcon:
+            self.document.HideFrame()
+        else:
+            event.Skip()
 
     def OnLogCtrlSize(self, evt):
         if self.mainSizeFlag:

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -522,6 +522,18 @@ class MainFrame(wx.Frame):
         return info[pos]
 
     def SetWindowStyleFlag(self, *args, **kwargs):
+        """
+        Changes the main frame style depending on the display of the tray icon.
+
+        sets the stlye flags fo the minimize button will be grayed out if the
+        tray icon is shown and there are any open child windows.
+        If the tray icon is not shown the minimize button will function as
+        usual.
+
+        :param args: unused parameter
+        :param kwargs: unused parameter
+        :return: None
+        """
         if eg.config.showTrayIcon:
             if len(self.openDialogs):
                 style = ~(wx.MINIMIZE_BOX | wx.CLOSE_BOX) & self.style

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -525,13 +525,15 @@ class MainFrame(wx.Frame):
         """
         Changes the main frame style depending on the display of the tray icon.
 
-        sets the stlye flags fo the minimize button will be grayed out if the
+        Sets the stlye flags fo the minimize button will be grayed out if the
         tray icon is shown and there are any open child windows.
         If the tray icon is not shown the minimize button will function as
         usual.
 
-        :param args: unused parameter
-        :param kwargs: unused parameter
+        :param args: unused, kept for compatibility with
+        wxFrame.SetWindowStyleFlag()
+        :param kwargs: unused, kept for compatibility with
+        wxFrame.SetWindowStyleFlag()
         :return: None
         """
         if eg.config.showTrayIcon:

--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -230,6 +230,9 @@ class OptionsDialog(eg.TaskletDialog):
         else:
             eg.taskBarIcon.Hide()
 
+        if eg.mainFrame:
+            eg.mainFrame.SetWindowStyleFlag()
+
         if config.language != oldLanguage:
             wx.CallAfter(self.ShowLanguageWarning)
 

--- a/eg/Classes/TaskBarIcon.py
+++ b/eg/Classes/TaskBarIcon.py
@@ -58,19 +58,25 @@ class TaskBarIcon(wx.TaskBarIcon):
         self.Bind(wx.EVT_TASKBAR_LEFT_DCLICK, self.OnCmdShow)
 
     def Close(self):
+        eg.mainFrame.Iconize(False)
         self.Hide()
 
     def Hide(self):
+        eg.mainFrame.Iconize(False)
         self.RemoveIcon()
 
     def OnCmdExit(self, event):
-        eg.app.Exit(event)
+        if len(eg.mainFrame.openDialogs) == 0:
+            eg.app.Exit(event)
+        else:
+            eg.mainFrame.Iconize(False)
+            eg.mainFrame.RequestUserAttention()
 
     def OnCmdHide(self, dummyEvent):
-        eg.document.HideFrame()
+        eg.mainFrame.Iconize(True)
 
     def OnCmdShow(self, dummyEvent=None):
-        eg.document.ShowFrame()
+        eg.mainFrame.Iconize(False)
 
     def OnProcessingChange(self, state):
         if self.IsIconInstalled():

--- a/eg/Classes/TaskBarIcon.py
+++ b/eg/Classes/TaskBarIcon.py
@@ -73,10 +73,14 @@ class TaskBarIcon(wx.TaskBarIcon):
             eg.mainFrame.RequestUserAttention()
 
     def OnCmdHide(self, dummyEvent):
-        eg.mainFrame.Iconize(True)
+        if eg.mainFrame is not None:
+            eg.mainFrame.Iconize(True)
 
     def OnCmdShow(self, dummyEvent=None):
-        eg.mainFrame.Iconize(False)
+        if eg.mainFrame is not None:
+            eg.mainFrame.Iconize(False)
+        else:
+            eg.document.ShowFrame()
 
     def OnProcessingChange(self, state):
         if self.IsIconInstalled():

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -67,6 +67,7 @@ eg.startupArguments = eg.Cli.args
 eg.debugLevel = eg.startupArguments.debugLevel
 eg.systemEncoding = locale.getdefaultlocale()[1]
 eg.document = None
+eg.mainFrame = None
 eg.result = None
 eg.plugins = eg.Bunch()
 eg.globals = eg.Bunch()

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -91,8 +91,13 @@ def InitGui():
 
     eg.document = eg.Document()
 
-    if not (eg.config.hideOnStartup or eg.startupArguments.hideOnStartup):
+    if eg.config.showTrayIcon:
+        if not (eg.config.hideOnStartup or eg.startupArguments.hideOnStartup):
+            eg.document.ShowFrame()
+    else:
         eg.document.ShowFrame()
+        if eg.config.hideOnStartup or eg.startupArguments.hideOnStartup:
+            eg.mainFrame.Iconize(True)
 
     eg.actionThread.Start()
 

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -90,7 +90,9 @@ def InitGui():
     eg.messageReceiver.Start()
 
     eg.document = eg.Document()
-    eg.mainFrame = eg.document.frame = eg.MainFrame(eg.document)
+
+    if not (eg.config.hideOnStartup or eg.startupArguments.hideOnStartup):
+        eg.document.ShowFrame()
 
     eg.actionThread.Start()
 

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -90,9 +90,7 @@ def InitGui():
     eg.messageReceiver.Start()
 
     eg.document = eg.Document()
-
-    if not (eg.config.hideOnStartup or eg.startupArguments.hideOnStartup):
-        eg.document.ShowFrame()
+    eg.mainFrame = eg.document.frame = eg.MainFrame(eg.document)
 
     eg.actionThread.Start()
 

--- a/eg/WinApi/COMServer.py
+++ b/eg/WinApi/COMServer.py
@@ -41,7 +41,10 @@ class EventGhostCom:
     _reg_clsctx_ = pythoncom.CLSCTX_LOCAL_SERVER
 
     def BringToFront(self):
-        eg.mainFrame.Iconize(False)
+        if eg.mainFrame is not None:
+            eg.mainFrame.Iconize(False)
+        else:
+            eg.document.ShowFrame()
 
     def InstallPlugin(self, pluginFile):
         import wx

--- a/eg/WinApi/COMServer.py
+++ b/eg/WinApi/COMServer.py
@@ -41,7 +41,7 @@ class EventGhostCom:
     _reg_clsctx_ = pythoncom.CLSCTX_LOCAL_SERVER
 
     def BringToFront(self):
-        eg.document.ShowFrame()
+        eg.mainFrame.Iconize(False)
 
     def InstallPlugin(self, pluginFile):
         import wx


### PR DESCRIPTION
Fixes the taskbar icon removal when show tray icon is not selected.

Fixes the empty log when maxamizing the frame

EG was set to destroy the frame when minimized. this would cause both of the bugs. because the frame would be destryoed so would the logCtrl, therefore deleting any data that may have been in the log. It would also remove the icon from the taskbar because the frame no longer exists.

I Have changed it to hide the frame if the tray icon is to be displayed and to let windows do it's windows thing if not. This doesn't destroy the logCtrl keeping the log data in tact