### PR TITLE
Fix passing of additional parameters to eg.SpinNumCtrl

### DIFF
--- a/eg/Classes/SpinIntCtrl.py
+++ b/eg/Classes/SpinIntCtrl.py
@@ -34,7 +34,7 @@ class SpinIntCtrl(eg.SpinNumCtrl):
         min=0,
         max=None,
         size=(-1, -1),
-        **kwargs
+        style=0
     ):
         allowNegative = bool(min < 0)
         if max is None:
@@ -51,8 +51,7 @@ class SpinIntCtrl(eg.SpinNumCtrl):
             max=max,
             size=size,
             allowNegative=allowNegative,
-            groupDigits=False,
+            groupDigits = False,
             fractionWidth=0,
-            integerWidth=integerWidth,
-            **kwargs
+            integerWidth=integerWidth
         )

--- a/eg/Classes/SpinIntCtrl.py
+++ b/eg/Classes/SpinIntCtrl.py
@@ -34,7 +34,7 @@ class SpinIntCtrl(eg.SpinNumCtrl):
         min=0,
         max=None,
         size=(-1, -1),
-        style=0
+        **kwargs
     ):
         allowNegative = bool(min < 0)
         if max is None:
@@ -51,7 +51,8 @@ class SpinIntCtrl(eg.SpinNumCtrl):
             max=max,
             size=size,
             allowNegative=allowNegative,
-            groupDigits = False,
+            groupDigits=False,
             fractionWidth=0,
-            integerWidth=integerWidth
+            integerWidth=integerWidth,
+            **kwargs
         )

--- a/eg/Classes/SpinIntCtrl.py
+++ b/eg/Classes/SpinIntCtrl.py
@@ -37,6 +37,7 @@ class SpinIntCtrl(eg.SpinNumCtrl):
         **kwargs
     ):
         allowNegative = bool(min < 0)
+
         if max is None:
             integerWidth = 5
         else:

--- a/eg/Classes/SpinNumCtrl.py
+++ b/eg/Classes/SpinNumCtrl.py
@@ -56,7 +56,8 @@ class SpinNumCtrl(wx.Window):
         **kwargs
     ):
         if "increment" in kwargs:
-            self.increment = kwargs.pop("increment")
+            self.increment = kwargs["increment"]
+            del kwargs["increment"]
         else:
             self.increment = 1
 
@@ -64,28 +65,31 @@ class SpinNumCtrl(wx.Window):
         tmp.update(kwargs)
         kwargs = tmp
 
-        if kwargs['min'] < 0:
+        minValue = kwargs.pop("min")
+        if minValue < 0:
             kwargs["allowNegative"] = True
         if "max" not in kwargs:
             kwargs["max"] = (
                 (10 ** kwargs["integerWidth"]) -
                 (10 ** -kwargs["fractionWidth"])
             )
-
         wx.Window.__init__(self, parent, id, pos, size, 0)
         self.SetThemeEnabled(True)
         numCtrl = masked.NumCtrl(
             self,
             -1,
-            value,
+            0,  # Can't set value here, to avoid bug in NumCtrl
             pos,
             size,
             style,
             validator,
             name,
             allowNone=True,
-            **kwargs
+            #**kwargs # Can't set kwargs here, to avoid bug in NumCtrl
         )
+        numCtrl.SetParameters(**kwargs)  # To avoid bug in NumCtrl
+        numCtrl.SetValue(value)  # To avoid bug in NumCtrl
+        numCtrl.SetMin(minValue)
 
         self.numCtrl = numCtrl
         numCtrl.SetCtrlParameters(
@@ -93,7 +97,6 @@ class SpinNumCtrl(wx.Window):
             emptyBackgroundColour=GetColour(wx.SYS_COLOUR_WINDOW),
             foregroundColour=GetColour(wx.SYS_COLOUR_WINDOWTEXT),
         )
-
         numCtrl.SetLimited(True)
         height = numCtrl.GetSize()[1]
         spinbutton = wx.SpinButton(

--- a/eg/Classes/SpinNumCtrl.py
+++ b/eg/Classes/SpinNumCtrl.py
@@ -56,8 +56,7 @@ class SpinNumCtrl(wx.Window):
         **kwargs
     ):
         if "increment" in kwargs:
-            self.increment = kwargs["increment"]
-            del kwargs["increment"]
+            self.increment = kwargs.pop("increment")
         else:
             self.increment = 1
 
@@ -65,31 +64,28 @@ class SpinNumCtrl(wx.Window):
         tmp.update(kwargs)
         kwargs = tmp
 
-        minValue = kwargs.pop("min")
-        if minValue < 0:
+        if kwargs['min'] < 0:
             kwargs["allowNegative"] = True
         if "max" not in kwargs:
             kwargs["max"] = (
                 (10 ** kwargs["integerWidth"]) -
                 (10 ** -kwargs["fractionWidth"])
             )
+
         wx.Window.__init__(self, parent, id, pos, size, 0)
         self.SetThemeEnabled(True)
         numCtrl = masked.NumCtrl(
             self,
             -1,
-            0,  # Can't set value here, to avoid bug in NumCtrl
+            value,
             pos,
             size,
             style,
             validator,
             name,
             allowNone=True,
-            #**kwargs # Can't set kwargs here, to avoid bug in NumCtrl
+            **kwargs
         )
-        numCtrl.SetParameters(**kwargs)  # To avoid bug in NumCtrl
-        numCtrl.SetValue(value)  # To avoid bug in NumCtrl
-        numCtrl.SetMin(minValue)
 
         self.numCtrl = numCtrl
         numCtrl.SetCtrlParameters(
@@ -97,6 +93,7 @@ class SpinNumCtrl(wx.Window):
             emptyBackgroundColour=GetColour(wx.SYS_COLOUR_WINDOW),
             foregroundColour=GetColour(wx.SYS_COLOUR_WINDOWTEXT),
         )
+
         numCtrl.SetLimited(True)
         height = numCtrl.GetSize()[1]
         spinbutton = wx.SpinButton(

--- a/eg/Classes/SpinNumCtrl.py
+++ b/eg/Classes/SpinNumCtrl.py
@@ -33,15 +33,15 @@ class SpinNumCtrl(wx.Window):
     A wx.Control that shows a fixed width floating point value and spin
     buttons to let the user easily input a floating point value.
     """
-    _defaultArgs = {
-        "integerWidth": 3,
-        "fractionWidth": 2,
-        "allowNegative": False,
-        "min": 0,
-        "limited": True,
-        "groupChar": THOUSANDS_SEP,
-        "decimalChar": DECIMAL_POINT,
-    }
+    _defaultArgs = dict(
+        integerWidth=3,
+        fractionWidth=2,
+        allowNegative=False,
+        min=0,
+        limited=True,
+        groupChar=THOUSANDS_SEP,
+        decimalChar=DECIMAL_POINT
+    )
 
     def __init__(
         self,
@@ -66,6 +66,7 @@ class SpinNumCtrl(wx.Window):
 
         if kwargs['min'] < 0:
             kwargs["allowNegative"] = True
+
         if "max" not in kwargs:
             kwargs["max"] = (
                 (10 ** kwargs["integerWidth"]) -


### PR DESCRIPTION
Fixes the passing of any additional keywords to eg.SpinNumCtrl.
Removes old bug patches from eg.SpinNumCtrl that are no longer an issue
Removes unused style keyword from eg.SpinIntCtrl
Minor code Cleanup