### PR TITLE
[System] - Bugfix - Allow multiple quoted arguments in calls to CMD via /S

### DIFF
--- a/plugins/System/Command.py
+++ b/plugins/System/Command.py
@@ -128,10 +128,10 @@ class Command(eg.ActionBase):
                 eg.folderPath.TemporaryFiles,
                 "EventGhost-output-%s.txt" % ttime()
             )
-            processInformation.lpParameters = '/C %s > %s' % (command, filename)
+            processInformation.lpParameters = '/S/C "%s" > %s' % (command, filename)
             processInformation.fMask = SEE_MASK_NOCLOSEPROCESS
         else:
-            processInformation.lpParameters = '/C %s' % command
+            processInformation.lpParameters = '/S/C "%s"' % command
         if runAsAdmin:
             processInformation.lpVerb = "runas"
         processInformation.nShow = 0
@@ -288,7 +288,7 @@ class Command(eg.ActionBase):
 
 def popen(cmd, si):
     return Popen(
-        'cmd /C %s' % cmd,
+        'cmd /S/C "%s"' % cmd,
         stdout = PIPE,
         stderr = open(devnull),
         startupinfo = si,


### PR DESCRIPTION
This fixes the "Run Command" action of the System plugin to allow the command and one or more arguments to have quotes/spaces in them.  As reported at http://www.eventghost.net/forum/viewtopic.php?f=4&t=9491

Basically, `cmd /c` does not work well when there are multiple quoted arguments in the command line.  `cmd /s/c` always just removes the first and last quote, so by adding extra such quotes at either end, we prevent actual quote removal.  (As the code is currently, `cmd` sometimes removes the first and last quote, even if there are other quotes in between, which changes the pairing among quotes!)