### PR TITLE
[Speech] Fix wxGridSizer error when adding action

### DIFF
--- a/plugins/Speech/__init__.py
+++ b/plugins/Speech/__init__.py
@@ -383,7 +383,7 @@ class TextToSpeech(eg.ActionClass):
             (sizer2, 0, wx.EXPAND|wx.ALL, 5),
         )
         ACV = wx.ALIGN_CENTER_VERTICAL
-        sizer3 = wx.FlexGridSizer(4, 2, 5, 5)
+        sizer3 = wx.FlexGridSizer(0, 2, 5, 5)
         sizer3.AddGrowableCol(1, 1)
         sizer3.AddMany(
             (


### PR DESCRIPTION
Before this change adding the "Text to speech" action causes the following
error:
```
PyAssertionError: C++ assertion "Assert failure" failed at ..\..\src\common\sizer.cpp(1401) in wxGridSizer::DoInsert(): too many items (9 > 2*4) in grid sizer (maybe you should omit the number of either rows or columns?)
```
I have no clue what the reason is for this error but setting the rows
argument to 0 causes FlexGridSizer to automatically set the value and
the error no longer occurs.

Issue report: https://github.com/EventGhost/EventGhost/issues/148