### PR TITLE
[Speech] Fix issue with strings in TextToSpeech action

### DIFF
--- a/plugins/Speech/__init__.py
+++ b/plugins/Speech/__init__.py
@@ -79,8 +79,6 @@ import pythoncom
 
 
 class Text:
-    name = "Text to speech"
-    description = "Uses the Microsoft Speech API (SAPI) to speak a text."
     label = "Speak: %s"
     errorCreate = "Cannot create voice object"
     buttonInsertTime = "Insert time HH:MM:SS"
@@ -100,6 +98,9 @@ class Text:
     suffix = "SpeakingFinished"
     addSuffix = "Additional event suffix:"
     device = "Output device:"
+    class TextToSpeech:
+        name = "Text to speech"
+        description = "Uses the Microsoft Speech API (SAPI) to speak a text."
 
 
 class CustomSlider(wx.Window):
@@ -239,7 +240,7 @@ class Speech(eg.PluginClass):
 
 
 class TextToSpeech(eg.ActionClass):
-    text = Text()
+    baseText = Text()
 
     def __call__(self, voiceName, rate, voiceText, suff, volume, device = None):
         self.suff = suff if suff != 0 else ""
@@ -277,7 +278,7 @@ class TextToSpeech(eg.ActionClass):
 
 
     def GetLabel(self, voiceName, rate, voiceText, suff, volume, device = None):
-        return self.text.label % voiceText
+        return self.baseText.label % voiceText
 
 
     def Configure(
@@ -290,7 +291,7 @@ class TextToSpeech(eg.ActionClass):
         device = None
     ):
         suff = suff if suff != 0 else ""
-        text = self.text
+        text = self.baseText
         panel = eg.ConfigPanel()
         plugin = self.plugin
 


### PR DESCRIPTION
A change in EventGhost starting with 0.5.0-beta1 seems to have changed how the
string class is handled, breaking the Speech plugin.

Previous to this change attempting to add the Text to speech action fails
with:
```
"AttributeError: class TextToSpeech has no attribute 'buttonInsertTime'"
```
Previous to this change the TextToSpeech action did not display the correct
name and had no description.

The reason I've done the `baseText = Text` instead of creating a `TextToSpeech`
string class as recommended in the [internationalisation documentation](http://www.eventghost.net/docs/internationalisation.html) is the
`Speaker` and `TextToSpeech` classes both use the `errorCreate` string and this
allows them to share the same string instead of having two duplicate strings
to maintain.

This change appears to make https://github.com/EventGhost/EventGhost/commit/5f76f85d8978786fc7068123924e50ba164c32d6 unnecessary in that the infinite loop no longer occurs even with `Text` instead of `Text()`. So it might be worth considering reverting that change unless there is a good reason to leave it since `text = Text` is the approach recommended in the documentation and anything else may lead to confusion.

To be honest I don't really know what I'm doing here. This was the result of trial and error. I don't know if this is the best way of going about this. I'm also not sure if `baseText` is an appropriate name. If anyone has input on improvements please let me know.

Issue report: https://github.com/EventGhost/EventGhost/issues/148