### PR TITLE
[EventGhost] - BugFix - eg.UndoHandler.Paste, Fixes duplicate GUIDs on tree Items

### DIFF
--- a/eg/Classes/UndoHandler/Paste.py
+++ b/eg/Classes/UndoHandler/Paste.py
@@ -108,6 +108,7 @@ class Paste(UndoHandlerBase):
                 if pos + 1 == len(before.parent.childs):
                     pos = -1
             newNode = childCls(selection, childXmlNode)
+            newNode.guid = eg.GUID.NewId(newNode)
             newNode.RestoreState()
             selection.AddChild(newNode, pos)
             self.items.append(eg.TreePosition(newNode))


### PR DESCRIPTION
as reported in #159 

If a tree item was copied and then pasted this would result in a duplicate GUID. This fix creates a new GUID for the copied tree item.