### PR TITLE
Change latest build link to master branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Great! Bugs are, unfortunately, a fact of software development life, but with yo
 Before continuing, be sure to:
 
 * Search [our issue tracker](https://github.com/EventGhost/EventGhost/issues) to see if your bug has already been identified. If you find a match, +1s aren't helpful to us, but any further light you can shed on the issue absolutely is.
-* Try [the latest stable version](http://www.eventghost.org/downloads/) and [the latest development version](https://ci.appveyor.com/project/blackwind/eventghost/build/artifacts). Your bug might already be fixed!
+* Try [the latest stable version](http://www.eventghost.org/downloads/) and [the latest development version](https://ci.appveyor.com/project/blackwind/eventghost/branch/master/artifacts). Your bug might already be fixed!
 
 ### Things to include in your bug report
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ![EventGhost Logo](images/logo.png)
-# EventGhost   [![Build Status](https://ci.appveyor.com/api/projects/status/3wf2sdw8bf4i02b9/branch/master?svg=true)](https://ci.appveyor.com/project/blackwind/eventghost/build/artifacts)   [![Slack](https://eventghost-slackin.herokuapp.com/badge.svg)](https://eventghost-slackin.herokuapp.com/)   [![Code Climate](https://codeclimate.com/github/EventGhost/EventGhost/badges/gpa.svg)](https://codeclimate.com/github/EventGhost/EventGhost)   [![Test Coverage](https://codeclimate.com/github/EventGhost/EventGhost/badges/coverage.svg)](https://codeclimate.com/github/EventGhost/EventGhost/coverage)
+# EventGhost   [![Build Status](https://ci.appveyor.com/api/projects/status/3wf2sdw8bf4i02b9/branch/master?svg=true)](https://ci.appveyor.com/project/blackwind/eventghost/branch/master/artifacts)   [![Slack](https://eventghost-slackin.herokuapp.com/badge.svg)](https://eventghost-slackin.herokuapp.com/)   [![Code Climate](https://codeclimate.com/github/EventGhost/EventGhost/badges/gpa.svg)](https://codeclimate.com/github/EventGhost/EventGhost)   [![Test Coverage](https://codeclimate.com/github/EventGhost/EventGhost/badges/coverage.svg)](https://codeclimate.com/github/EventGhost/EventGhost/coverage)
 
 
 


### PR DESCRIPTION
Previously the "latest development version" and the build status badge
links would pick up builds from pull requests.

This change will cause the links to always point to the latest build of
the EventGhost/EventGhost master branch.

Fixes #160