### PR TITLE
[Remote Event Mapper] Fix rendering of reStructuredText in description

### DIFF
--- a/plugins/RemoteEventMapper/__init__.py
+++ b/plugins/RemoteEventMapper/__init__.py
@@ -42,8 +42,8 @@ eg.RegisterPlugin(
     version = version,
     kind = "other",
     guid = "{FF85940E-9E93-453C-903B-736FCE0863FF}",
-    description = u'''
-<rst>**This plugin is designed for easy remapping of events from remote controls.**
+    description = u'''<rst>
+**This plugin is designed for easy remapping of events from remote controls.**
 
 Using this plugin has several advantages:
 


### PR DESCRIPTION
Previously the reStructuredText markup of the plugin description was
not being rendered in the EventGhost "Add Plugin" dialog.

Before:
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/21842551/31786df0-d79c-11e6-8335-cfdf2c0b8b6c.png)
After:
![clipboard02](https://cloud.githubusercontent.com/assets/8572152/21842560/3734de7c-d79c-11e6-9717-1f36de8f55ef.png)