### PR TITLE
Change "Search our issue tracker" link to also show closed issues and PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Great! Bugs are, unfortunately, a fact of software development life, but with yo
 
 Before continuing, be sure to:
 
-* Search [our issue tracker](https://github.com/EventGhost/EventGhost/issues) to see if your bug has already been identified. If you find a match, +1s aren't helpful to us, but any further light you can shed on the issue absolutely is.
+* Search [our issue tracker](https://github.com/EventGhost/EventGhost/issues?q=) to see if your bug has already been identified. If you find a match, +1s aren't helpful to us, but any further light you can shed on the issue absolutely is.
 * Try [the latest stable version](http://www.eventghost.org/downloads/) and [the latest development version](https://ci.appveyor.com/project/topic2k/eventghost/branch/master/artifacts). Your bug might already be fixed!
 
 ### Things to include in your bug report


### PR DESCRIPTION
The previous link filtered the search to only include open issues, which
may lead to the submission of duplicate/unnecessary issue reports from
people who don't realize they need to clear those filters when searching
for related issues/pull requests that were previously submitted.

Previous link(filtered by `is:issue is:open`): https://github.com/EventGhost/EventGhost/issues
New link(unfiltered): https://github.com/EventGhost/EventGhost/issues?q=