### PR TITLE
[System] - Bugfix - MonitorPowerOn not working in Windows 8 & 10

### DIFF
--- a/plugins/System/__init__.py
+++ b/plugins/System/__init__.py
@@ -24,6 +24,8 @@ import thread
 import time
 import wx
 import _winreg
+import win32con
+import win32gui
 from base64 import b64decode, b64encode
 from PIL import Image
 from qrcode import QRCode, constants as QRconstants
@@ -107,6 +109,22 @@ EVENT_LIST = (
     ("DeviceAttached", None),
     ("DeviceRemoved", None),
 )
+
+MONITOR_STATES = dict(
+    OFF=2,
+    STANDBY=1,
+    ON=-1
+)
+
+
+def MonitorState(state):
+    win32gui.SendMessage(
+        win32con.HWND_BROADCAST,
+        win32con.WM_SYSCOMMAND,
+        SC_MONITORPOWER,
+        MONITOR_STATES[state]
+    )
+
 
 class Text:
     class MonitorGroup:
@@ -681,7 +699,7 @@ class MonitorPowerOff(eg.ActionBase):
     iconFile = "icons/Display"
 
     def __call__(self):
-        SendMessage(GetForegroundWindow(), WM_SYSCOMMAND, SC_MONITORPOWER, 2)
+        MonitorState('OFF')
 
 
 class MonitorPowerOn(eg.ActionBase):
@@ -693,7 +711,7 @@ class MonitorPowerOn(eg.ActionBase):
     iconFile = "icons/Display"
 
     def __call__(self):
-        SendMessage(GetForegroundWindow(), WM_SYSCOMMAND, SC_MONITORPOWER, -1)
+        MonitorState('ON')
 
 
 class MonitorStandby(eg.ActionBase):
@@ -702,7 +720,7 @@ class MonitorStandby(eg.ActionBase):
     iconFile = "icons/Display"
 
     def __call__(self):
-        SendMessage(GetForegroundWindow(), WM_SYSCOMMAND, SC_MONITORPOWER, 1)
+        MonitorState('STANDBY')
 
 
 class SetDisplayPreset(eg.ActionBase):


### PR DESCRIPTION
Fixes not being able to turn the monitor on from the System.MonitorPowerOn action when running Windows 8 or Windows 10.

Changed MonitorPowerOff and MonitorStandby to use the same mechanism.

SendMessage from WinApi/Dynamic is actually an alias for ctypes.WinDLL('user32').SendMessageW. and as this does not cause an issue with windows 7 it seems to not work for Windows 8 or 10 for turning the monitor back on

so the change I made uses pywin32 instead of ctypes and it powers the monitor on properly