### PR TITLE
Dialog gets stuck if a traceback occurs during it's creation.

### DIFF
--- a/eg/Classes/MainFrame/TreeCtrl.py
+++ b/eg/Classes/MainFrame/TreeCtrl.py
@@ -799,6 +799,8 @@ class TreeCtrl(wx.TreeCtrl):
         """
         if node not in self.visibleNodes:
             path = node.GetPath()
+            if path is None:
+                return
             parent = self.root
             for pos in path[:-1]:
                 childNode = parent.childs[pos]

--- a/eg/Classes/TaskletDialog.py
+++ b/eg/Classes/TaskletDialog.py
@@ -162,7 +162,6 @@ class TaskletDialog(wx.Dialog, eg.ControlProviderMixin):
             self.Configure(*args, **kwargs)
         except:
             eg.PrintTraceback()
-
         self.__done = True
         self.__resultsChannel.send((None, None))
         self.Destroy()

--- a/eg/Classes/TaskletDialog.py
+++ b/eg/Classes/TaskletDialog.py
@@ -162,10 +162,10 @@ class TaskletDialog(wx.Dialog, eg.ControlProviderMixin):
             self.Configure(*args, **kwargs)
         except:
             eg.PrintTraceback()
+
         self.__done = True
         self.__resultsChannel.send((None, None))
-        if self.setupFinished:
-            self.Destroy()
+        self.Destroy()
 
     @eg.LogItWithReturn
     def SetResult(self, *args):

--- a/eg/Classes/TreeItem.py
+++ b/eg/Classes/TreeItem.py
@@ -68,7 +68,7 @@ class TreeItem(object):
             self.guid = eg.GUID.NewId(self)
         else:
             self.guid = eg.GUID.AddId(self, guid)
-            
+
         if isinstance(self.name, str):
             self.name = unicode(self.name, "utf8")
         self.isEnabled = not get('enabled') == "False"
@@ -279,6 +279,8 @@ class TreeItem(object):
         path = []
         while item is not root:
             parent = item.parent
+            if parent is None:
+                return None
             path.append(parent.childs.index(item))
             item = parent
         path.reverse()


### PR DESCRIPTION
if a traceback occurs during the creation of a dialog. a notification was already sent out to add the dialog to mainframes openDialogs. the FinishSetup method in TaskletDialog never gets to run there for never setting the setupFinished flag. so when the exception gets caught and printed and should happen along it's merry way there is some checking of the setupFinished and the destruction on the dialog only occurs when setupFinished is set to True. so a notification never gets sent to remove the dialog from the list. causing the "phantom dialog" effect. forcing you to kill the EventGhost process because the main frame thinks there is still an open dialog. 

Upon fixing this issue I happened upon 2 others caused by thread timing. The 2 things that were happening in 2 different threads are the selecting of the treeItem and the deleting of the treeItem. so what would happen is in the middle of the treeItem being selected it would get deleted. causing additional tracebacks.. which should not have happened. those are fixed as well..

