### PR TITLE
[ProcessWatcher] - Enhancement - Adds ability to change polling time

### DIFF
--- a/plugins/ProcessWatcher/__init__.py
+++ b/plugins/ProcessWatcher/__init__.py
@@ -18,6 +18,16 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
+# ChangeLog
+
+# 30-1-2017 8:46 GMT -7:00      K
+#   Added: Polling speed adjustment by the user
+#   Added: Dynamic polling speed change via an action
+#   Added: Select which processes to trigger events for
+#   Changed: How the thread terminates
+#   Changed: Replaced time.sleep with threading.Event
+
+
 import eg
 
 
@@ -26,8 +36,10 @@ eg.RegisterPlugin(
     author = (
         "Bitmonster",
         "DranDane",
+        "Sem;colon",
+        "K"
     ),
-    version = "1.0.",
+    version = "1.2.0",
     guid = "{82BADF9F-D809-4EBC-A540-CCBF7563F8DF}",
     description = (
         "Generates events if a process is created or destoyed"
@@ -52,6 +64,7 @@ import wx
 from eg.cFunctions import GetProcessDict
 from os.path import splitext
 import threading
+from fnmatch import fnmatch
 from eg.WinApi.Dynamic import (
 # functions:
     CreateEvent,
@@ -59,9 +72,13 @@ from eg.WinApi.Dynamic import (
 )
 
 
+class Config(eg.PersistentData):
+    processes = []
+
 class Text(eg.TranslatableStrings):
 
     pollLbl = 'Default Poll Interval:'
+    processNamesLbl = 'Allowed Processes (no checks = all processes)'
     resetMessage = 'ProcessWatcher: Setting poll interval %.2f back to %.2f'
     changeMessage = (
         'ProcessWatcher: Setting poll interval %.2f for %.2f seconds'
@@ -72,26 +89,188 @@ class Text(eg.TranslatableStrings):
     class PollInterval:
         name = 'Change Poll Interval'
         description = (
-            'Sets the duration of time between checking the process list for '
-            'changes'
+            'Sets the duration of time between checking the process\n'
+            'list for changes.'
         )
         pollLbl = 'New Poll Interval:'
         durationLbl = 'Interval Duration:'
         descLbl = (
-            '\n\nHow long to keep the new polling interval set for.\n'
-            'Set to 0 to keep indefinitely\n\n'
+            '\nHow long to keep the new polling interval set for.\n'
+            'Set to 0 to keep indefinitely\n'
         )
+
+    class GetProcessesByName:
+        name = 'Get processes by name'
+        description = (
+            'Returns an array of dicts with processes (pid and name)\n'
+            'that match a process name.'
+        )
+        processNameLbl = 'Process name:'
+
+
+    class GetProcessByPid:
+        name = 'Get process by PID'
+        description = 'Returns True if the PID exists and False if not.'
+        pidLbl = 'PID:'
+
+
+class Process(eg.PluginClass):
+
+    text = Text
+
+    def __init__(self):
+        self.AddAction(PollInterval)
+        self.AddAction(GetProcessByPid)
+        self.AddAction(GetProcessesByName)
+
+        self._processNameList = Config.processes
+        self._allowedEvents = ()
+        self._threadEvent = threading.Event()
+        self._pollInterval = 0.1
+        self._resetIntervalTimer = None
+        self._defaultInterval = 0.1
+        self._processes = GetProcessDict()
+        self._thread = None
+        self.info.eventPrefix = "Process"
+
+    def __start__(self, pollInterval=0.1, processNameList=()):
+        self._allowedEvents = processNameList
+
+        while self._threadEvent.isSet():
+            pass
+
+        self._pollInterval = pollInterval
+        self._defaultInterval = pollInterval
+
+        self._thread = threading.Thread(
+            target=self.ThreadLoop,
+            name="ProcessWatcherThread",
+        )
+
+        self._thread.start()
+
+    def __stop__(self):
+        Config.processes = self._processNameList
+        self.StopIntervalTimer()
+
+        if self._thread is not None:
+            self._threadEvent.set()
+            self._thread.join(5.0)
+
+    def ResetInterval(self):
+        eg.Print(
+            self.text.resetMessage %
+            (self._pollInterval, self._defaultInterval)
+        )
+        self._pollInterval = self._defaultInterval
+        self._resetIntervalTimer = None
+
+    def StopIntervalTimer(self):
+        try:
+            self._resetIntervalTimer.stop()
+        except AttributeError:
+            pass
+        self._resetIntervalTimer = None
+
+    def SetInterval(self, pollInterval, duration):
+        eg.Print(
+            self.text.changeMessage %
+            (pollInterval, duration)
+        )
+        self._pollInterval = pollInterval
+        self.StopIntervalTimer()
+        if duration:
+            self._resetIntervalTimer = threading.Timer(
+                duration,
+                self.ResetInterval
+            )
+            self._resetIntervalTimer.start()
+
+    def TriggerEvents(self, suffix, set1, set2, processes):
+        for pid in set1.difference(set2):
+            name = splitext(processes[pid])[0]
+
+            if name not in self._processNameList:
+                self._processNameList.append(name)
+
+            if not self._allowedEvents or name in self._allowedEvents:
+                self.TriggerEvent(suffix=suffix + name, payload=dict(pid=pid))
+
+    def ThreadLoop(self):
+        eg.Print(self.text.startMessage)
+        oldPids = set(key for key in self._processes.keys())
+
+        while not self._threadEvent.isSet():
+            newProcesses = GetProcessDict()
+            newPids = set(key for key in newProcesses.keys())
+
+            self.TriggerEvents("Created.", newPids, oldPids, newProcesses)
+            self.TriggerEvents("Destroyed.", oldPids, newPids, self._processes)
+            self._processes = newProcesses
+            oldPids = newPids
+            self._threadEvent.wait(self._pollInterval)
+
+        self._threadEvent.clear()
+        eg.Print(self.text.stopMessage)
+
+    def Configure(self, pollInterval=0.1, processNamesList=()):
+        text = self.text
+        panel = eg.ConfigPanel()
+
+        processNamesList = list(processNamesList)
+
+        pollST = panel.StaticText(text.pollLbl)
+        pollCtrl = panel.SpinNumCtrl(
+            pollInterval,
+            min=0.05,
+            max=1.0,
+            increment=0.05
+        )
+
+        processNamesST = panel.StaticText(text.processNamesLbl)
+        processNamesCtrl = wx.CheckListBox(
+            panel,
+            choices=self._processNameList
+        )
+        if processNamesCtrl.GetCount():
+            processNamesCtrl.SetCheckedStrings(processNamesList)
+            if processNamesList:
+                processNamesCtrl.SetFirstItem(len(processNamesList) - 1)
+            else:
+                processNamesCtrl.SetFirstItem(0)
+
+        pollSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        pollSizer.Add(pollST, 0, wx.EXPAND | wx.ALL, 10)
+        pollSizer.Add(pollCtrl, 0, wx.EXPAND | wx.ALL, 10)
+        panel.sizer.Add(pollSizer, 0, wx.EXPAND)
+        panel.sizer.Add(
+            processNamesST,
+            0,
+            wx.EXPAND | wx.ALIGN_CENTER | wx.ALL,
+            10
+        )
+        panel.sizer.Add(
+            processNamesCtrl,
+            1,
+            wx.EXPAND | wx.RIGHT | wx.LEFT | wx.BOTTOM,
+            10
+        )
+
+        while panel.Affirmed():
+            panel.SetResult(
+                pollCtrl.GetValue(),
+                processNamesCtrl.GetCheckedStrings()
+            )
 
 
 class PollInterval(eg.ActionBase):
-
     def __call__(self, pollInterval, duration):
-
         self.plugin.SetInterval(pollInterval, duration)
 
     def GetLabel(self, pollInterval, duration):
         return Text.changeMessage % (pollInterval, duration)
-        
+
     def Configure(self, pollInterval=None, duration=0.0):
 
         if pollInterval is None:
@@ -135,118 +314,43 @@ class PollInterval(eg.ActionBase):
             )
 
 
-class Process(eg.PluginClass):
+class GetProcessByPid(eg.ActionBase):
+    def __call__(self, pid):
+        return pid in GetProcessDict()
 
-    text = Text
-
-    def __init__(self):
-        self.AddAction(PollInterval)
-        self._threadEvent = threading.Event()
-        self._pollInterval = 0.1
-        self._resetIntervalTimer = None
-        self._defaultInterval = 0.1
-
-    def __start__(self, pollInterval=0.1):
-
-        while self._threadEvent.isSet():
-            pass
-
-        self._pollInterval = pollInterval
-        self._defaultInterval = pollInterval
-
-        self.stopEvent = CreateEvent(None, 1, 0, None)
-        self.startException = None
-
-        startupEvent = threading.Event()
-
-        self.thread = threading.Thread(
-            target=self.ThreadLoop,
-            name="ProcessWatcherThread",
-            args=(startupEvent,)
-        )
-
-        self.thread.start()
-        startupEvent.wait(3)
-        if self.startException is not None:
-            raise self.Exception(self.startException)
-
-    def __stop__(self):
-        self.StopIntervalTimer()
-
-        if self.thread is not None:
-            self._threadEvent.set()
-            PulseEvent(self.stopEvent)
-            self.thread.join(5.0)
-
-    def ResetInterval(self):
-        eg.Print(
-            self.text.resetMessage %
-            (self._pollInterval, self._defaultInterval)
-        )
-        self._pollInterval = self._defaultInterval
-        self._resetIntervalTimer = None
-
-    def StopIntervalTimer(self):
-        try:
-            self._resetIntervalTimer.stop()
-        except AttributeError:
-            pass
-        self._resetIntervalTimer = None
-
-    def SetInterval(self, pollInterval, duration):
-        eg.Print(
-            self.text.changeMessage %
-            (pollInterval, duration)
-        )
-        self._pollInterval = pollInterval
-        self.StopIntervalTimer()
-        if duration:
-            self._resetIntervalTimer = threading.Timer(
-                duration,
-                self.ResetInterval
-            )
-            self._resetIntervalTimer.start()
-
-    def Configure(self, pollInterval=0.1):
+    def Configure(self, pid=0):
         text = self.text
         panel = eg.ConfigPanel()
 
-        pollST = panel.StaticText(text.pollLbl)
-        pollCtrl = panel.SpinNumCtrl(
-            pollInterval,
-            min=0.05,
-            max=1.0,
-            increment=0.05
-        )
+        wx_pid = panel.SpinIntCtrl(pid, min=0)
+        st_pid = panel.StaticText(text.pidLbl)
 
-        pollSizer = wx.BoxSizer(wx.HORIZONTAL)
-
-        pollSizer.Add(pollST, 0, wx.EXPAND | wx.ALL, 10)
-        pollSizer.Add(pollCtrl, 0, wx.EXPAND | wx.ALL, 10)
-        panel.sizer.Add(pollSizer, 0, wx.EXPAND)
+        panel.AddLine(st_pid, wx_pid)
 
         while panel.Affirmed():
-            panel.SetResult(
-                pollCtrl.GetValue()
-            )
+            panel.SetResult(wx_pid.GetValue())
 
-    def ThreadLoop(self, stopThreadEvent):
-        oldProcesses = GetProcessDict()
-        oldPids = set(oldProcesses.iterkeys())
 
-        eg.Print(self.text.startMessage)
+class GetProcessesByName(eg.ActionBase):
+    def __call__(self, processName):
+        processes = GetProcessDict()
+        pids = set(key for key in processes.keys())
+        result = []
+        for pid in pids:
+            name = splitext(processes[pid])[0]
+            if fnmatch(name, processName):
+                result.append({"pid": pid, "name": name})
+        return result
 
-        while not self._threadEvent.isSet():
-            newProcesses = GetProcessDict()
-            newPids = set(newProcesses.iterkeys())
-            for pid in newPids.difference(oldPids):
-                name = splitext(newProcesses[pid])[0]
-                eg.TriggerEvent("Created." + name, prefix="Process")
-            for pid in oldPids.difference(newPids):
-                name = splitext(oldProcesses[pid])[0]
-                eg.TriggerEvent("Destroyed." + name, prefix="Process")
-            oldProcesses = newProcesses
-            oldPids = newPids
-            self._threadEvent.wait(self._pollInterval)
-        self._threadEvent.clear()
-        eg.Print(self.text.stopMessage)
+    def Configure(self, processName=""):
+        text = self.text
+        panel = eg.ConfigPanel()
+
+        wx_processName = panel.TextCtrl(processName)
+        st_processName = panel.StaticText(text.processNameLbl)
+
+        panel.AddLine(st_processName, wx_processName)
+
+        while panel.Affirmed():
+            panel.SetResult(wx_processName.GetValue())
+


### PR DESCRIPTION
Adds a plugin config option to set the polling interval by setting a lower number this will remove some CPU load time.

Changed the use of Time.sleep to threading.Event to allow the thread to exit in a clean manner

Added an action to dynamically change the polling interval with a timer to reset it back. This would be used if you were looking for a chain of things to happen and didn't need to have it running at full speed all the time. and the Timer to set it back is a convenience thing. if the Timer value is set to 0 it will remain at the new value.