### PR TITLE
SpinNumCtrl: Re-add workaround for traceback if min value > 0

### DIFF
--- a/eg/Classes/SpinNumCtrl.py
+++ b/eg/Classes/SpinNumCtrl.py
@@ -76,15 +76,18 @@ class SpinNumCtrl(wx.Window):
         numCtrl = masked.NumCtrl(
             self,
             -1,
-            value,
+            0, # Can't set value here, to avoid bug in NumCtrl
             pos,
             size,
             style,
             validator,
             name,
             allowNone=True,
-            **kwargs
+            # **kwargs # Can't set kwargs here, to avoid bug in NumCtrl
         )
+        numCtrl.SetParameters(**kwargs)  # To avoid bug in NumCtrl
+        numCtrl.SetValue(value)  # To avoid bug in NumCtrl
+        numCtrl.SetMin(minValue)
 
         self.numCtrl = numCtrl
         numCtrl.SetCtrlParameters(
@@ -160,7 +163,7 @@ class SpinNumCtrl(wx.Window):
         This is the function that gets called in response to up/down arrow or
         bound spin button events.
         """
-        
+
         # Ensure adjusted control regains focus and has adjusted portion
         # selected:
         numCtrl = self.numCtrl


### PR DESCRIPTION
Re-adds the setting of the value other parameters until after the control has been initialized.

We had thought this issue fixed in the new version of wx and also tested and it worked properly. but there is a random issue that can show up. and this issue has not been fixed by the wx team. So the workaround had to be put back in