### PR TITLE
[EventGhost] - [Bugfix, Enhancement] - eg.event.payload, Adds handling of payload data being None

### DIFF
--- a/eg/Classes/EventGhostEvent.py
+++ b/eg/Classes/EventGhostEvent.py
@@ -101,6 +101,9 @@ class EventGhostEvent(object):
         self.shouldEnd = Event()
         self.upFuncList = []
 
+    def HasPayload(self):
+        return self.payload != eg.NoPayloadData
+
     def AddUpFunc(self, func, *args, **kwargs):
         if self.isEnded:
             func(*args, **kwargs)

--- a/eg/Classes/EventGhostEvent.py
+++ b/eg/Classes/EventGhostEvent.py
@@ -83,11 +83,18 @@ class EventGhostEvent(object):
     """
     skipEvent = False
 
-    def __init__(self, suffix="", payload=None, prefix="Main", source=eg):
+    def __init__(
+        self,
+        suffix="",
+        payload=eg.DummyPayload,
+        prefix="Main",
+        source=eg
+    ):
         self.string = prefix + "." + suffix
         self.prefix = prefix
         self.suffix = suffix
-        self.payload = payload
+        if payload != eg.DummyPayload:
+            self.payload = payload
         self.source = source
         self.time = clock()
         self.isEnded = False

--- a/eg/Classes/EventGhostEvent.py
+++ b/eg/Classes/EventGhostEvent.py
@@ -82,19 +82,19 @@ class EventGhostEvent(object):
 
     """
     skipEvent = False
+    NoPayloadData = eg.NoPayloadData
 
     def __init__(
         self,
         suffix="",
-        payload=eg.DummyPayload,
+        payload=eg.NoPayloadData,
         prefix="Main",
         source=eg
     ):
         self.string = prefix + "." + suffix
         self.prefix = prefix
         self.suffix = suffix
-        if payload != eg.DummyPayload:
-            self.payload = payload
+        self.payload = payload
         self.source = source
         self.time = clock()
         self.isEnded = False

--- a/eg/Classes/EventThread.py
+++ b/eg/Classes/EventThread.py
@@ -86,7 +86,7 @@ class EventThread(ThreadWorker):
     def TriggerEnduringEvent(
         self,
         suffix,
-        payload=eg.DummyPayload,
+        payload=eg.NoPayloadData,
         prefix="Main",
         source=eg
     ):
@@ -105,7 +105,7 @@ class EventThread(ThreadWorker):
     def TriggerEvent(
         self,
         suffix,
-        payload=eg.DummyPayload,
+        payload=eg.NoPayloadData,
         prefix="Main",
         source=eg
     ):
@@ -128,7 +128,7 @@ class EventThread(ThreadWorker):
     def TriggerEventWait(
         self,
         suffix,
-        payload=eg.DummyPayload,
+        payload=eg.NoPayloadData,
         prefix="Main",
         source=eg
     ):

--- a/eg/Classes/EventThread.py
+++ b/eg/Classes/EventThread.py
@@ -86,7 +86,7 @@ class EventThread(ThreadWorker):
     def TriggerEnduringEvent(
         self,
         suffix,
-        payload=None,
+        payload=eg.DummyPayload,
         prefix="Main",
         source=eg
     ):
@@ -102,7 +102,13 @@ class EventThread(ThreadWorker):
 
         return event
 
-    def TriggerEvent(self, suffix, payload=None, prefix="Main", source=eg):
+    def TriggerEvent(
+        self,
+        suffix,
+        payload=eg.DummyPayload,
+        prefix="Main",
+        source=eg
+    ):
         """
         Trigger an event
         """
@@ -122,7 +128,7 @@ class EventThread(ThreadWorker):
     def TriggerEventWait(
         self,
         suffix,
-        payload=None,
+        payload=eg.DummyPayload,
         prefix="Main",
         source=eg
     ):

--- a/eg/Classes/Log.py
+++ b/eg/Classes/Log.py
@@ -131,13 +131,12 @@ class Log(object):
         """
         Store and display an EventGhostEvent in the logger.
         """
-        payload = event.payload
         eventstring = event.string
-        if payload is not None:
-            if type(payload) == UnicodeType:
-                mesg = eventstring + ' u"' + payload + '"'
+        if hasattr(event, 'payload'):
+            if type(event.payload) == UnicodeType:
+                mesg = eventstring + ' u"' + event.payload + '"'
             else:
-                mesg = eventstring + ' ' + repr(payload)
+                mesg = eventstring + ' ' + repr(event.payload)
         else:
             mesg = eventstring
         self.Write(mesg + "\n", eg.EventItem.icon, eventstring)

--- a/eg/Classes/Log.py
+++ b/eg/Classes/Log.py
@@ -131,12 +131,13 @@ class Log(object):
         """
         Store and display an EventGhostEvent in the logger.
         """
+        payload = event.payload
         eventstring = event.string
-        if hasattr(event, 'payload'):
-            if type(event.payload) == UnicodeType:
-                mesg = eventstring + ' u"' + event.payload + '"'
+        if payload != event.NoPayloadData:
+            if type(payload) == UnicodeType:
+                mesg = eventstring + ' u"' + payload + '"'
             else:
-                mesg = eventstring + ' ' + repr(event.payload)
+                mesg = eventstring + ' ' + repr(payload)
         else:
             mesg = eventstring
         self.Write(mesg + "\n", eg.EventItem.icon, eventstring)

--- a/eg/Classes/PluginBase.py
+++ b/eg/Classes/PluginBase.py
@@ -243,7 +243,11 @@ class PluginBase(object):
         """
         eg.PrintError(msg, source=self.info.treeItem)
 
-    def TriggerEnduringEvent(self, suffix, payload=None):
+    def TriggerEnduringEvent(
+        self,
+        suffix,
+        payload=eg.DummyPayload
+    ):
         """
         Trigger an enduring event.
 
@@ -268,7 +272,11 @@ class PluginBase(object):
             info.lastEvent = event
             return event
 
-    def TriggerEvent(self, suffix, payload=None):
+    def TriggerEvent(
+        self,
+        suffix,
+        payload=eg.DummyPayload
+    ):
         """
         Trigger an event.
 

--- a/eg/Classes/PluginBase.py
+++ b/eg/Classes/PluginBase.py
@@ -246,7 +246,7 @@ class PluginBase(object):
     def TriggerEnduringEvent(
         self,
         suffix,
-        payload=eg.DummyPayload
+        payload=eg.NoPayloadData
     ):
         """
         Trigger an enduring event.
@@ -275,7 +275,7 @@ class PluginBase(object):
     def TriggerEvent(
         self,
         suffix,
-        payload=eg.DummyPayload
+        payload=eg.NoPayloadData
     ):
         """
         Trigger an event.

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -89,6 +89,12 @@ eg.actionGroup.items = []
 eg.folderPath = eg.FolderPath()
 eg.GUID = eg.GUID()
 
+
+class DummyPayload:
+    pass
+
+eg.DummyPayload = DummyPayload
+
 def _CommandEvent():
     """Generate new (CmdEvent, Binder) tuple
         e.g. MooCmdEvent, EVT_MOO = EgCommandEvent()

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -90,10 +90,10 @@ eg.folderPath = eg.FolderPath()
 eg.GUID = eg.GUID()
 
 
-class DummyPayload:
+class NoPayloadData:
     pass
 
-eg.DummyPayload = DummyPayload
+eg.NoPayloadData = NoPayloadData
 
 def _CommandEvent():
     """Generate new (CmdEvent, Binder) tuple


### PR DESCRIPTION
This is probably going to break peoples code if it relies on None being no payload data. When in reality None could very well be the actual data. With how EG is currently set up one would never know. And currently if the payload is a None then EG will bypass printing it in the log.. and if it is an actual value it should be printed. This modification provides the mechanism to handle this. 

What I have done is created a class called NoPayloadData and attached it as the defaults in the various TriggerEvents throughout EG. and I have also provided a means to check if the payload data has been set or not by doing a comparison like below.

    if event.payload != event.NoPayloadData:
        # do code here

