### PR TITLE
Fixes log being scrolled to the top after restored from tray icon

### DIFF
--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -65,6 +65,7 @@ class Document(object):
         self.frame = None
         self.reentrantLock = Lock()
         self.expandedNodes = set()
+        self.visibleLogItem = 0
 
     def AfterLoad(self):
         if (
@@ -300,6 +301,14 @@ class Document(object):
         if self.reentrantLock.acquire(False):
             if self.frame is not None:
                 if len(self.frame.openDialogs) == 0:
+                    logCtrl = self.frame.logCtrl
+                    self.visibleLogItem = (
+                        logCtrl.GetTopItem() + logCtrl.GetCountPerPage()
+                    )
+
+                    if self.visibleLogItem:
+                        self.visibleLogItem -= 1
+
                     self.frame.Destroy()
                     self.frame = eg.mainFrame = None
             self.reentrantLock.release()

--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -302,12 +302,15 @@ class Document(object):
             if self.frame is not None:
                 if len(self.frame.openDialogs) == 0:
                     logCtrl = self.frame.logCtrl
-                    self.visibleLogItem = (
-                        logCtrl.GetTopItem() + logCtrl.GetCountPerPage()
-                    )
+                    if logCtrl.IsAutoscroll():
+                        self.visibleLogItem = 0
+                    else:
+                        self.visibleLogItem = (
+                            logCtrl.GetTopItem() + logCtrl.GetCountPerPage()
+                        )
 
-                    if self.visibleLogItem:
-                        self.visibleLogItem -= 1
+                        if self.visibleLogItem:
+                            self.visibleLogItem -= 1
 
                     self.frame.Destroy()
                     self.frame = eg.mainFrame = None

--- a/eg/Classes/MainFrame/LogCtrl.py
+++ b/eg/Classes/MainFrame/LogCtrl.py
@@ -276,8 +276,12 @@ class LogCtrl(wx.ListCtrl):
             self.Refresh()
 
     def Scroll(self):
-        if len(self.data) <= (self.GetTopItem() + self.GetCountPerPage() + 2):
+        if self.IsAutoscroll():
             self.ScrollList(0, 1000000)
+
+    def IsAutoscroll(self):
+        val = self.GetTopItem() + self.GetCountPerPage() + 2
+        return len(self.data) <= val
 
     @eg.AssertInMainThread
     def SetData(self, data):
@@ -287,7 +291,9 @@ class LogCtrl(wx.ListCtrl):
 
         if eg.document.visibleLogItem:
             self.EnsureVisible(eg.document.visibleLogItem)
-            
+        else:
+            self.EnsureVisible(len(self.data) - 1)
+
         # self.Thaw()
 
     def SetIndent(self, shouldIndent):

--- a/eg/Classes/MainFrame/LogCtrl.py
+++ b/eg/Classes/MainFrame/LogCtrl.py
@@ -281,11 +281,14 @@ class LogCtrl(wx.ListCtrl):
 
     @eg.AssertInMainThread
     def SetData(self, data):
-        #self.Freeze()
+        # self.Freeze()
         self.data = collections.deque(data)
         self.SetItemCount(len(data))
-        #self.Thaw()
-        self.Scroll()
+
+        if eg.document.visibleLogItem:
+            self.EnsureVisible(eg.document.visibleLogItem)
+            
+        # self.Thaw()
 
     def SetIndent(self, shouldIndent):
         if shouldIndent:


### PR DESCRIPTION
Fixes #198 
I also added a special feature to this. it will record the last position of the log before minimized to the tray (destroyed) and it will return to that position in the log when it is restored (recreated)

