### PR TITLE
[Build] Adds a couple wx modules to excluded list

### DIFF
--- a/_build/Build.py
+++ b/_build/Build.py
@@ -96,6 +96,9 @@ class MyBuilder(builder.Builder):
         "wx.lib.vtk",
         "wx.tools.Editra",
         "wx.tools.XRCed",
+        "wx.lib.pdfwin_old",
+        "wx.lib.pdfviewer",
+        "wx.lib.pubsub"
     ]
 
     def BuildInstaller(self):

--- a/_build/Build.py
+++ b/_build/Build.py
@@ -99,6 +99,8 @@ class MyBuilder(builder.Builder):
         "wx.lib.pdfwin_old",
         "wx.lib.pdfviewer",
         "wx.lib.pubsub"
+        "wx.lib.iewin",
+        "wx.lib.iewin_old"
     ]
 
     def BuildInstaller(self):


### PR DESCRIPTION
Adds wx.lib.pdfwin_old, wx.lib.pdfviewer and wx.lib.pubsub to excluded list when EG is being built. stopping the import errors