### PR TITLE
[System] Adds Windows XP support and moves the registering of the GUID's to the main thread

### DIFF
--- a/plugins/System/PowerBroadcastNotifier.py
+++ b/plugins/System/PowerBroadcastNotifier.py
@@ -62,29 +62,8 @@ SVR_ON = 0x1
 AWY_EXITING = 0x0
 AWY_ENTERING = 0x1
 
-PI = wx.PlatformInformation()
-# Windows 10 /  Server 2016
-WIN_10 = PI.CheckOSVersion(10, 0)
-WIN_8 = False
-WIN_7 = False
-WIN_VISTA = False
-WIN_XP = False
 
-if not WIN_10:
-    # Windows 8, 8.1 / Server 2012, 2012 R2 / RT, RT 8.1
-    WIN_8 = PI.CheckOSVersion(6, 2) or PI.CheckOSVersion(6, 3)
-if True not in (WIN_10, WIN_8):
-    # Windows 7 / Server 2008 R2
-    WIN_7 = PI.CheckOSVersion(6, 1)
-if True not in (WIN_10, WIN_8, WIN_7):
-    # Windows Vista / Server 2008
-    WIN_VISTA = PI.CheckOSVersion(6, 0)
-if True not in (WIN_10, WIN_8, WIN_7, WIN_VISTA):
-    # Windows XP x86, x64 / Server 2003, 2003 R2 / Tablet PC, MCE
-    WIN_XP = PI.CheckOSVersion(5, 1) or PI.CheckOSVersion(5, 2)
-
-
-if True in (WIN_8, WIN_10):
+if eg.WindowsVersion >= 8:
     GUID_CONSOLE_DISPLAY_STATE = GUID(
         '{6fe69556-704a-47a0-8f24-c28d936fda47}'
     )
@@ -155,7 +134,7 @@ POWER_MESSAGES = {
     # PBT_APMPOWERSTATUSCHANGE: "PowerStatusChange",
 }
 
-if WIN_XP:
+if eg.WindowsVersion.IsXP():
     POWER_MESSAGES.update({
         PBT_APMBATTERYLOW: 'BatteryLevel.Low', # pre win vista
         PBT_APMOEMEVENT: 'OemEvent', # pre win vista
@@ -219,7 +198,7 @@ class PowerBroadcastNotifier:
         self.savingNotify = None
         self.schemeNotify = None
 
-        if True in (WIN_10, WIN_8, WIN_7, WIN_VISTA):
+        if eg.WindowsVersion >= 'Vista':
             wx.CallAfter(self.RegisterMessages)
 
         eg.messageReceiver.AddHandler(
@@ -236,7 +215,7 @@ class PowerBroadcastNotifier:
         self.schemeNotify = Register(GUID_POWERSCHEME_PERSONALITY)
 
     def Close(self):
-        if True in (WIN_10, WIN_8, WIN_7, WIN_VISTA):
+        if eg.WindowsVersion >= 'Vista':
             Unregister(self.monitorNotify)
             Unregister(self.awayNotify)
             Unregister(self.sourceNotify)

--- a/plugins/System/PowerBroadcastNotifier.py
+++ b/plugins/System/PowerBroadcastNotifier.py
@@ -63,7 +63,7 @@ AWY_EXITING = 0x0
 AWY_ENTERING = 0x1
 
 
-if eg.WindowsVersion >= 8:
+if eg.WindowsVersion() >= 8:
     GUID_CONSOLE_DISPLAY_STATE = GUID(
         '{6fe69556-704a-47a0-8f24-c28d936fda47}'
     )
@@ -198,7 +198,7 @@ class PowerBroadcastNotifier:
         self.savingNotify = None
         self.schemeNotify = None
 
-        if eg.WindowsVersion >= 'Vista':
+        if eg.WindowsVersion() >= 'Vista':
             wx.CallAfter(self.RegisterMessages)
 
         eg.messageReceiver.AddHandler(
@@ -215,7 +215,7 @@ class PowerBroadcastNotifier:
         self.schemeNotify = Register(GUID_POWERSCHEME_PERSONALITY)
 
     def Close(self):
-        if eg.WindowsVersion >= 'Vista':
+        if eg.WindowsVersion() >= 'Vista':
             Unregister(self.monitorNotify)
             Unregister(self.awayNotify)
             Unregister(self.sourceNotify)

--- a/plugins/System/PowerBroadcastNotifier.py
+++ b/plugins/System/PowerBroadcastNotifier.py
@@ -16,13 +16,16 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
-# Local imports
-import eg
+# --------- 25/2/2017, 19:50 -7 ---------
+# Added Windows XP support
+# Thanks to Diz
+# ---------------------------------------
 
+import wx
 import ctypes
 from comtypes import GUID
-from eg.WinApi.SystemInformation import GetWindowsVersionString
 
+import eg
 from eg.WinApi.Dynamic import (
     windll,
     byref,
@@ -43,8 +46,18 @@ from eg.WinApi.Dynamic import (
 UCHAR = ctypes.c_ubyte
 DWORD = ctypes.wintypes.DWORD
 
-winVer = GetWindowsVersionString()[18:]
-WIN_7 = not (winVer.startswith('10') or winVer.startswith('8'))
+PI = wx.PlatformInformation()
+
+# Windows XP x86, x64 / Server 2003, 2003 R2 / Tablet PC, MCE
+WIN_XP = (PI.CheckOSVersion(5, 1) or PI.CheckOSVersion(5, 2))
+# Windows Vista / Server 2008
+WIN_VISTA = PI.CheckOSVersion(6, 0)
+# Windows 7 / Server 2008 R2
+WIN_7 = PI.CheckOSVersion(6, 1)
+# Windows 8, 8.1 / Server 2012, 2012 R2 / RT, RT 8.1
+WIN_8 = (PI.CheckOSVersion(6, 2) or PI.CheckOSVersion(6, 3))
+# Windows 10 /  Server 2016
+WIN_10 = PI.CheckOSVersion(10, 0)
 
 PBT_POWERSETTINGCHANGE = 0x8013
 
@@ -62,10 +75,10 @@ SVR_ON = 0x1
 AWY_EXITING = 0x0
 AWY_ENTERING = 0x1
 
-if WIN_7:
-    monGUID = '{02731015-4510-4526-99e6-e5a17ebd1aea}'
-else:
+if WIN_8 or WIN_10:
     monGUID = '{6fe69556-704a-47a0-8f24-c28d936fda47}'
+else:
+    monGUID = '{02731015-4510-4526-99e6-e5a17ebd1aea}'
 
 GUID_SYSTEM_AWAYMODE = GUID(
     '{98a7f580-01f7-48aa-9c0f-44352c29e5C0}'
@@ -97,55 +110,59 @@ GUID_TYPICAL_POWER_SAVINGS = GUID(
 )
 GUID_CONSOLE_DISPLAY_STATE = GUID(monGUID)
 
-POWER_MESSAGES = {
-    GUID_CONSOLE_DISPLAY_STATE: {
-        MON_OFF: 'Monitor.Off',
-        MON_ON: 'Monitor.On',
-        MON_DIM: 'Monitor.Dim'
-    },
-    GUID_SYSTEM_AWAYMODE: {
-        AWY_EXITING: 'AwayMode.Exiting',
-        AWY_ENTERING: 'AwayMode.Entering'
-    },
-    GUID_ACDC_POWER_SOURCE: {
-        PWR_AC: 'PowerSource.Line',
-        PWR_DC: 'PowerSource.Battery',
-        PWR_UPS: 'PowerSource.UPS'
-    },
-    GUID_BATTERY_PERCENTAGE_REMAINING: {
+POWER_MESSAGES = dict(
+    GUID_CONSOLE_DISPLAY_STATE=dict(
+        MON_OFF='Monitor.Off',
+        MON_ON='Monitor.On',
+        MON_DIM='Monitor.Dim'
+    ),
+    GUID_SYSTEM_AWAYMODE=dict(
+        AWY_EXITING='AwayMode.Exiting',
+        AWY_ENTERING='AwayMode.Entering'
+    ),
+    GUID_ACDC_POWER_SOURCE=dict(
+        PWR_AC='PowerSource.Line',
+        PWR_DC='PowerSource.Battery',
+        PWR_UPS='PowerSource.UPS'
+    ),
+    GUID_BATTERY_PERCENTAGE_REMAINING={
         i: 'BatteryLevel.' + str(i) + '%' for i in range(101)
     },
-    GUID_POWER_SAVING_STATUS: {
-        SVR_OFF: 'PowerSaving.Off',
-        SVR_ON: 'PowerSaving.On'
-    },
-    GUID_POWERSCHEME_PERSONALITY: {
-        GUID_MIN_POWER_SAVINGS: 'PowerProfile.PowerSaver',
-        GUID_MAX_POWER_SAVINGS: 'PowerProfile.HighPerformance',
-        GUID_TYPICAL_POWER_SAVINGS: 'PowerProfile.Balanced'
-    },
-    PBT_APMBATTERYLOW: 'BatteryLevel.Low', # pre win vista
-    PBT_APMOEMEVENT: 'OemEvent', # pre win vista
-    PBT_APMQUERYSUSPENDFAILED: 'QuerySuspendFailed', # pre win vista
-    PBT_APMRESUMECRITICAL: 'ResumeCritical', # pre win vista
-    PBT_APMQUERYSUSPEND: 'QuerySuspend', # pre win vista
-    PBT_APMRESUMEAUTOMATIC: 'ResumeAutomatic',
-    PBT_APMRESUMESUSPEND: 'Resume',
-    PBT_APMSUSPEND: 'Suspend'
+    GUID_POWER_SAVING_STATUS=dict(
+        SVR_OFF='PowerSaving.Off',
+        SVR_ON='PowerSaving.On'
+    ),
+    GUID_POWERSCHEME_PERSONALITY=dict(
+        GUID_MIN_POWER_SAVINGS='PowerProfile.PowerSaver',
+        GUID_MAX_POWER_SAVINGS='PowerProfile.HighPerformance',
+        GUID_TYPICAL_POWER_SAVINGS='PowerProfile.Balanced'
+    ),
+    PBT_APMRESUMEAUTOMATIC='ResumeAutomatic',
+    PBT_APMRESUMESUSPEND='Resume',
+    PBT_APMSUSPEND='Suspend'
     # PBT_APMPOWERSTATUSCHANGE: "PowerStatusChange",
-}
+)
+
+if WIN_XP:
+    POWER_MESSAGES.update(dict(
+        PBT_APMBATTERYLOW='BatteryLevel.Low', # pre win vista
+        PBT_APMOEMEVENT='OemEvent', # pre win vista
+        PBT_APMQUERYSUSPENDFAILED='QuerySuspendFailed', # pre win vista
+        PBT_APMRESUMECRITICAL='ResumeCritical', # pre win vista
+        PBT_APMQUERYSUSPEND='QuerySuspend', # pre win vista
+    ))
+
+else:
+    def Register(guid):
+        return windll.user32.RegisterPowerSettingNotification(
+            eg.messageReceiver.hwnd,
+            byref(guid),
+            0
+        )
 
 
-def Register(guid):
-    return windll.user32.RegisterPowerSettingNotification(
-        eg.messageReceiver.hwnd,
-        byref(guid),
-        0
-    )
-
-
-def Unregister(cls):
-    return windll.user32.UnregisterDeviceNotification(cls)
+    def Unregister(cls):
+        return windll.user32.UnregisterDeviceNotification(cls)
 
 
 class POWERBROADCAST_SETTING(ctypes.Structure):
@@ -185,12 +202,13 @@ class PowerBroadcastNotifier:
     def __init__(self, plugin):
         self.plugin = plugin
 
-        self.monitorNotify = Register(GUID_CONSOLE_DISPLAY_STATE)
-        self.awayNotify = Register(GUID_SYSTEM_AWAYMODE)
-        self.sourceNotify = Register(GUID_ACDC_POWER_SOURCE)
-        self.batteryNotify = Register(GUID_BATTERY_PERCENTAGE_REMAINING)
-        self.savingNotify = Register(GUID_POWER_SAVING_STATUS)
-        self.schemeNotify = Register(GUID_POWERSCHEME_PERSONALITY)
+        if not WIN_XP:
+            self.monitorNotify = Register(GUID_CONSOLE_DISPLAY_STATE)
+            self.awayNotify = Register(GUID_SYSTEM_AWAYMODE)
+            self.sourceNotify = Register(GUID_ACDC_POWER_SOURCE)
+            self.batteryNotify = Register(GUID_BATTERY_PERCENTAGE_REMAINING)
+            self.savingNotify = Register(GUID_POWER_SAVING_STATUS)
+            self.schemeNotify = Register(GUID_POWERSCHEME_PERSONALITY)
 
         eg.messageReceiver.AddHandler(
             WM_POWERBROADCAST,
@@ -198,12 +216,13 @@ class PowerBroadcastNotifier:
         )
 
     def Close(self):
-        Unregister(self.monitorNotify)
-        Unregister(self.awayNotify)
-        Unregister(self.sourceNotify)
-        Unregister(self.batteryNotify)
-        Unregister(self.savingNotify)
-        Unregister(self.schemeNotify)
+        if not WIN_XP:
+            Unregister(self.monitorNotify)
+            Unregister(self.awayNotify)
+            Unregister(self.sourceNotify)
+            Unregister(self.batteryNotify)
+            Unregister(self.savingNotify)
+            Unregister(self.schemeNotify)
 
         eg.messageReceiver.RemoveHandler(
             WM_POWERBROADCAST,


### PR DESCRIPTION
Windows XP does not support the use of RegisterPowerNotification and UnregisterPowerNotificatrion it always sends the notification. I want to thank Diz for providing the solution to fix this. Tho I did modify it so that in the future any new Windows versions will force a review of the code. I did this because of how Microsoft likes to change things about. We do want to make sure we have a working plugin. So in the event that there is an unsupported GUID in a new OS it will not register the GUID's because all of the OS checks will return False. 

The Registering of the GUID's is much happier being done in the main thread. even tho it does appear to work if done in another thread, it does not function properly. I discovered this issue when working with another part of EG that also uses win32com and when i had an error while working with that it would also cause the PowerBroadcastNotifier to throw a traceback. and only the PowerBroadcastNotifier would even tho the use of win32com is use throughout EG. and one of the traceback has some information in it about not being run in the main thread. 

And now since it is done in the main thread there are a couple of new events on startup as well. this is a good indicator it is functioning properly. And I believe this is the fix for #181. Not setting those GUID's in the main thread really mucks up odd parts of pywin32. I feel this is something that we may need to monkey patch pywin32 to have it throw an exception if it is not being done in the main thread as to avoid any future issues, IE: my forgetfulness or even a plugin dev. I suggest this because there is no indication there is a problem just random weird things happening.