### PR TITLE
Add class for windows version checking

### DIFF
--- a/_build/builder/BuildDocs.py
+++ b/_build/builder/BuildDocs.py
@@ -51,6 +51,7 @@ MAIN_CLASSES = [
     "ConfigPanel",
     "Bunch",
     "WindowMatcher",
+    "WindowsVersion",
     "-EventGhostEvent",
     "-Scheduler",
     "-ControlProviderMixin",

--- a/eg/Classes/App.py
+++ b/eg/Classes/App.py
@@ -25,7 +25,7 @@ import wx
 import eg
 from eg.WinApi.Dynamic import ExitProcess, SetProcessShutdownParameters
 
-IS_VISTA = eg.Utils.IsVista()
+IS_VISTA = eg.WindowsVersion.IsVista()
 
 if IS_VISTA:
     from eg.WinApi.Dynamic import _user32, BOOL, HWND, LPCWSTR

--- a/eg/Classes/WinUsb.py
+++ b/eg/Classes/WinUsb.py
@@ -423,7 +423,7 @@ class WinUsb(object):
             try:
                 result = ExecAs(
                     "subprocess",
-                    eg.Utils.IsVista() or not IsAdmin(),
+                    eg.WindowsVersion.IsVista() or not IsAdmin(),
                     "call",
                     cmdLine.encode('mbcs'),
                 )

--- a/eg/Classes/WindowsVersion.py
+++ b/eg/Classes/WindowsVersion.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.org/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+A convenience module for checking the windows version.
+Functions:
+    IsXP()
+    IsVista()
+    Is7()
+    Is8()
+    Is10()
+"""
+
+import sys
+import wx
+
+PI = wx.PlatformInformation()
+
+WIN_10 = PI.CheckOSVersion(10, 0)
+WIN_8 = False
+WIN_7 = False
+WIN_VISTA = False
+WIN_XP = False
+
+if not WIN_10:
+    WIN_8 = PI.CheckOSVersion(6, 2) or PI.CheckOSVersion(6, 3)
+if True not in (WIN_10, WIN_8):
+    WIN_7 = PI.CheckOSVersion(6, 1)
+if True not in (WIN_10, WIN_8, WIN_7):
+    WIN_VISTA = PI.CheckOSVersion(6, 0)
+if True not in (WIN_10, WIN_8, WIN_7, WIN_VISTA):
+    WIN_XP = PI.CheckOSVersion(5, 1) or PI.CheckOSVersion(5, 2)
+
+
+def IsXP():
+    """
+    Checks if Windows version is:
+    Windows XP x86
+    Windows XP x64
+    Windows Server 2003
+    Windows 2003 R2
+    Windows Tablet PC
+    Windows Media Center Edition 2002
+    Windows Media Center Edition 2004
+    Windows Media Center Edition 2005
+    :return: Bool
+    """
+    return WIN_XP
+
+
+def IsVista():
+    """
+    Checks if Windows version is:
+    Windows Vista
+    Windows Server 2008
+    :return: Bool
+    """
+    return WIN_VISTA
+
+
+def Is7():
+    """
+    Checks if Windows version is:
+    Windows 7
+    Windows Server 2008 R2
+    :return: Bool
+    """
+    return WIN_7
+
+
+def Is8():
+    """
+    Checks if Windows version is:
+    Windows 8
+    Windows 8.1
+    Windows Server 2012
+    Windows 2012 R2
+    Windows RT
+    Windows RT 8.1
+    :return: Bool
+    """
+    return WIN_8
+
+
+def Is10():
+    """
+    Checks if Windows version is:
+    Windows 10
+    Windows Server 2016
+    :return: Bool
+    """
+    return WIN_10
+
+
+WindowsVersion = sys.modules[__name__]

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -53,6 +53,7 @@ eg.CORE_PLUGIN_GUIDS = (
     "{E974D074-B0A3-4D0C-BBD1-992475DDD69D}",  # "Window"
     "{6B1751BF-F94E-4260-AB7E-64C0693FD959}",  # "Mouse"
 )
+
 eg.ID_TEST = wx.NewId()
 eg.mainDir = eg.Cli.mainDir
 eg.imagesDir = join(eg.mainDir, "images")

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -129,7 +129,7 @@ def InitGui():
             wx.CallAfter(eg.CheckUpdate.Start)
 
     # Register restart handler for easy crash recovery.
-    if eg.Utils.IsVista():
+    if eg.WindowsVersion.IsVista():
         args = " ".join(eg.app.GetArguments())
         windll.kernel32.RegisterApplicationRestart(args, 8)
 

--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -21,6 +21,7 @@ import os
 import sys
 import threading
 import time
+import warnings
 import wx
 from CommonMark import commonmark
 from ctypes import c_ulonglong, windll
@@ -33,6 +34,13 @@ from types import ClassType
 
 # Local imports
 import eg
+
+# Make sure our deprecation warnings will be shown
+warnings.filterwarnings(
+    action="always",
+    category=DeprecationWarning,
+    module='^eg\..*'
+)
 
 __all__ = [
     "Bunch", "NotificationHandler", "LogIt", "LogItWithReturn", "TimeIt",
@@ -384,13 +392,25 @@ def IsVista():
     """
     Determine if we're running Vista or higher.
     """
-    return (sys.getwindowsversion()[0] >= 6)
+    warnings.warn(
+        "eg.Utils.IsVista() is deprecated. "
+        "Use eg.WindowsVersion.IsVista() instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return eg.WindowsVersion.IsVista()
 
 def IsXP():
     """
     Determine if we're running XP or higher.
     """
-    return (sys.getwindowsversion()[0:2] >= (5, 1))
+    warnings.warn(
+        "eg.Utils.IsXP() is deprecated. "
+        "Use eg.WindowsVersion.IsXP() instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return eg.WindowsVersion.IsXP()
 
 def LogIt(func):
     """

--- a/eg/__init__.py
+++ b/eg/__init__.py
@@ -30,6 +30,7 @@ import win32api  # NOQA
 # Local imports
 import Cli
 from Utils import *  # NOQA
+from Classes.WindowsVersion import WindowsVersion
 
 class DynamicModule(object):
     def __init__(self):

--- a/plugins/RFXcom_xPL/__init__.py
+++ b/plugins/RFXcom_xPL/__init__.py
@@ -263,7 +263,7 @@ class RFXcom(eg.PluginClass):
         logStr = timeStamp+"\t"+s+"<br\n>"
         fileHandle = None
 
-        if eg.Utils.IsVista():
+        if eg.WindowsVersion.IsVista():
             progData = os.environ['ALLUSERSPROFILE']
             if (
                 not os.path.exists(progData+"/EventGhost/Log")

--- a/plugins/System/__init__.py
+++ b/plugins/System/__init__.py
@@ -234,7 +234,7 @@ class System(eg.PluginBase):
         self.powerBroadcastNotifier = PowerBroadcastNotifier(self)
 
         # start the session change notifications (only on Win XP and above)
-        if eg.Utils.IsXP():
+        if eg.WindowsVersion.IsXP():
             from SessionChangeNotifier import SessionChangeNotifier
             self.sessionChangeNotifier = SessionChangeNotifier(self)
 
@@ -243,7 +243,7 @@ class System(eg.PluginBase):
         eg.Bind("System.SessionUnlock", self.StartHookCode)
 
         # Use VistaVolume.dll from stridger for sound volume control on Vista
-        if eg.Utils.IsVista():
+        if eg.WindowsVersion.IsVista():
             import VistaVolEvents as vistaVolumeDll
             vistaVolumeDll.RegisterVolumeHandler(self.VolumeEvent)
             vistaVolumeDll.RegisterMuteHandler(self.MuteEvent)
@@ -1954,7 +1954,7 @@ class ChangeMasterVolumeBy(eg.ActionBase):
         deviceCtrl = panel.Choice(
             deviceId + 1, choices=SoundMixer.GetMixerDevices(True)
         )
-        #if eg.Utils.IsVista():
+        #if eg.WindowsVersion.IsVista():
         #    deviceCtrl.SetValue(0)
         #    deviceCtrl.Enable(False)
 
@@ -2004,7 +2004,7 @@ class GetMute(eg.ActionBase):
         deviceCtrl = panel.Choice(
             deviceId + 1, choices=SoundMixer.GetMixerDevices(True)
         )
-        """if eg.Utils.IsVista():
+        """if eg.WindowsVersion.IsVista():
             deviceCtrl.SetValue(0)
             deviceCtrl.Enable(False)"""
         #panel.AddLine("Device:", deviceCtrl)
@@ -2032,7 +2032,7 @@ class MuteOff(eg.ActionBase):
         deviceCtrl = panel.Choice(
             deviceId + 1, choices=SoundMixer.GetMixerDevices(True)
         )
-        """if eg.Utils.IsVista():
+        """if eg.WindowsVersion.IsVista():
             deviceCtrl.SetValue(0)
             deviceCtrl.Enable(False)"""
         #panel.AddLine("Device:", deviceCtrl)
@@ -2060,7 +2060,7 @@ class MuteOn(eg.ActionBase):
         deviceCtrl = panel.Choice(
             deviceId + 1, choices=SoundMixer.GetMixerDevices(True)
         )
-        """if eg.Utils.IsVista():
+        """if eg.WindowsVersion.IsVista():
             deviceCtrl.SetValue(0)
             deviceCtrl.Enable(False)"""
         #panel.AddLine("Device:", deviceCtrl)
@@ -2158,7 +2158,7 @@ class SetMasterVolume(eg.ActionBase):
             deviceId + 1, choices=SoundMixer.GetMixerDevices(True)
         )
 #        deviceCtrl = panel.Choice(deviceId, SoundMixer.GetMixerDevices())
-        """if eg.Utils.IsVista():
+        """if eg.WindowsVersion.IsVista():
             deviceCtrl.SetValue(0)
             deviceCtrl.Enable(False)"""
         valueCtrl = panel.SmartSpinNumCtrl(value, min=0, max=100)
@@ -2218,7 +2218,7 @@ class ToggleMute(eg.ActionBase):
         deviceCtrl = panel.Choice(
             deviceId + 1, choices=SoundMixer.GetMixerDevices(True)
         )
-        """if eg.Utils.IsVista():
+        """if eg.WindowsVersion.IsVista():
             deviceCtrl.SetValue(0)
             deviceCtrl.Enable(False)"""
         #panel.AddLine("Device:", deviceCtrl)

--- a/plugins/Webserver/__init__.py
+++ b/plugins/Webserver/__init__.py
@@ -900,7 +900,7 @@ class MyServer(ThreadingMixIn, HTTPServer):
 
     def server_bind(self):
         """Called by constructor to bind the socket."""
-        if socket.has_ipv6 and eg.Utils.IsVista():
+        if socket.has_ipv6 and eg.WindowsVersion.IsVista():
             # make it a dual-stack socket if OS is Vista/Win7
             IPPROTO_IPV6 = 41
             self.socket.setsockopt(IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)


### PR DESCRIPTION
replaces #208 
based on the idea from @kdschlosser, extended to a class with compare functions.

Check for a specific Windows version:
`eg.WindowsVersion.IsVista()`  or `eg.WindowsVersion == "Vista"`

Check for a minimum Windows version:
`eg.WindowsVersion >= "Vista"`

**Notice for plugin developers:** `eg.Utils.IsXP()` and `eg.Utils.IsVista()` are now deprecated.

---
**Functions:**
```
IsXP()
IsVista()
Is7()
Is8()
Is80()
Is81()
Is10()
```
**Comparison:**
```
eg.WindowsVersion [<|<=|==|!=|>=|>] "[XP|Vista|7|8|80|81|10]"

XP:    Windows XP
       Windows Server 2003
       Windows 2003 R2
       Windows Tablet PC
       Windows Media Center Edition 2002
       Windows Media Center Edition 2004
       Windows Media Center Edition 2005
Vista: Windows Vista
       Windows Server 2008
7:     Windows 7
       Windows Server 2008 R2
8:     (80 and 81)
80:    Windows 8
       Windows Server 2012
       Windows RT
81:    Windows 8.1
       Windows 2012 R2
       Windows RT 8.1
10:    Windows 10
       Windows Server 2016
```