### PR TITLE
[Eventghost] - Enhancement - WindowsVersion, Fixes issue with help

### DIFF
--- a/eg/Classes/WindowsVersion.py
+++ b/eg/Classes/WindowsVersion.py
@@ -16,8 +16,11 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
+from .. import Cli
+
 import platform
 from collections import OrderedDict
+
 
 WINDOWS_VERSIONS = OrderedDict()
 WINDOWS_VERSIONS["XP"] = [[5, 1], [5, 2]]
@@ -349,3 +352,6 @@ class WindowsVersion:
         :rtype: bool
         """
         return _compare('==', "10")
+
+if Cli.args.isMain:
+    WindowsVersion = WindowsVersion()

--- a/eg/Classes/WindowsVersion.py
+++ b/eg/Classes/WindowsVersion.py
@@ -81,7 +81,7 @@ class WindowsVersion:
 
     In addition to the *IsXY()* methods, you can use comparison like this:
 
-    ``eg.WindowsVersion() OPERATOR "KEY"``
+    ``eg.WindowsVersion OPERATOR "KEY"``
 
     ``OPERATOR`` is one of ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``
 

--- a/plugins/System/PowerBroadcastNotifier.py
+++ b/plugins/System/PowerBroadcastNotifier.py
@@ -63,7 +63,7 @@ AWY_EXITING = 0x0
 AWY_ENTERING = 0x1
 
 
-if eg.WindowsVersion() >= 8:
+if eg.WindowsVersion >= 8:
     GUID_CONSOLE_DISPLAY_STATE = GUID(
         '{6fe69556-704a-47a0-8f24-c28d936fda47}'
     )
@@ -198,7 +198,7 @@ class PowerBroadcastNotifier:
         self.savingNotify = None
         self.schemeNotify = None
 
-        if eg.WindowsVersion() >= 'Vista':
+        if eg.WindowsVersion >= 'Vista':
             wx.CallAfter(self.RegisterMessages)
 
         eg.messageReceiver.AddHandler(
@@ -215,7 +215,7 @@ class PowerBroadcastNotifier:
         self.schemeNotify = Register(GUID_POWERSCHEME_PERSONALITY)
 
     def Close(self):
-        if eg.WindowsVersion() >= 'Vista':
+        if eg.WindowsVersion >= 'Vista':
             Unregister(self.monitorNotify)
             Unregister(self.awayNotify)
             Unregister(self.sourceNotify)


### PR DESCRIPTION
Fixes issue with help not being generated if WindowsVersion gets constructed. 

I used Cli.args.isMain to determine if the build process is running. this allows for eg.WindowsVersion to not be constructed and the help to be built