### PR TITLE
[EventGhost] (PythonScript) Fixes PrintError traceback

### DIFF
--- a/eg/Classes/ActionItem.py
+++ b/eg/Classes/ActionItem.py
@@ -197,6 +197,7 @@ class ActionItem(TreeItem):
 
     @eg.AssertInActionThread
     def SetArguments(self, args):
+        eg.currentItem = self
         if self.args != args:
             self.args = args
             try:

--- a/plugins/EventGhost/PythonScript.py
+++ b/plugins/EventGhost/PythonScript.py
@@ -79,6 +79,7 @@ class PythonScript(eg.ActionBase):
 
         def PrintTraceback(self):
             treeItem = eg.currentItem
+            wx.CallAfter(treeItem.Select)
             treeItem.PrintError("Traceback (most recent call last):")
             lines = self.sourceCode.splitlines()
             tbType, tbValue, tbTraceback = sys.exc_info()


### PR DESCRIPTION
This is an odd problem. it's a traceback caused by a traceback..

If you have a compile error in a python script but do not fix it.. then restart EG you will get this traceback

    Error compiling script.
    Traceback (most recent call last) (1722):
    File "C:\Program Files (x86)\EventGhost\eg\Classes\ActionItem.py", line 121, in SetArguments
    self.compiled = self.executable.Compile(*args)
    File "C:\Program Files (x86)\EventGhost\plugins\EventGhost\PythonScript.py", line 71, in __init__
    self.PrintTraceback()
    File "C:\Program Files (x86)\EventGhost\plugins\EventGhost\PythonScript.py", line 97, in PrintTraceback
    treeItem.PrintError("Traceback (most recent call last):")
    AttributeError: 'NoneType' object has no attribute 'PrintError'

this is from PythonScript using eg.currentItem and when this error occurs eg.currentItem does not get set. so this sets eg.currentItem just before the script gets compiled. 

Now we all know how hard it is to try and weed out which python script it is. this can be very daunting if you have alot of them. because EG currently uses numbers as an identifier for the python script unless you keep track of what number is which one you will still have to hunt. 

So what i did was if a traceback occurs and since the tree item is used to print the error. I also have it select that tree item. this now is a nice way to identify which one caused the error