### PR TITLE
MainMessageReceiver: Fixes broken clipboard chain in windows 10 (reported by saue0)

### DIFF
--- a/eg/Classes/MainMessageReceiver.py
+++ b/eg/Classes/MainMessageReceiver.py
@@ -53,6 +53,7 @@ class MainMessageReceiver(eg.MessageReceiver):
         self.hwndNextViewer = SetClipboardViewer(self.hwnd)
         self.AddHandler(WM_DRAWCLIPBOARD, self.OnDrawClipboard)
 
-    def Finish(self):
-        ChangeClipboardChain(self.hwnd, self.hwndNextViewer)
-        eg.MessageReceiver.Finish(self)
+    @eg.LogIt
+    def Stop(self):
+        self.Func(ChangeClipboardChain)(self.hwnd, self.hwndNextViewer)
+        eg.MessageReceiver.Stop(self)

--- a/eg/Classes/MainMessageReceiver.py
+++ b/eg/Classes/MainMessageReceiver.py
@@ -17,7 +17,6 @@
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
 import wx
-from threading import Lock, ThreadError
 
 # Local imports
 import eg
@@ -28,7 +27,6 @@ from eg.WinApi.Dynamic import (
 
 class MainMessageReceiver(eg.MessageReceiver):
     def __init__(self):
-        self.finishLock = Lock()
         self.hwndNextViewer = None
         eg.MessageReceiver.__init__(self, "EventGhost Message Receiver")
 
@@ -41,10 +39,6 @@ class MainMessageReceiver(eg.MessageReceiver):
                 self.hwndNextViewer = None
         elif self.hwndNextViewer:
             SendMessage(self.hwndNextViewer, mesg, wParam, lParam)
-        try:
-            self.finishLock.acquire()
-        except ThreadError:
-            pass
         return 0
 
     def OnDrawClipboard(self, dummyHwnd, mesg, wParam, lParam):
@@ -61,9 +55,4 @@ class MainMessageReceiver(eg.MessageReceiver):
 
     def Finish(self):
         ChangeClipboardChain(self.hwnd, self.hwndNextViewer)
-        self.finishLock.acquire()
         eg.MessageReceiver.Finish(self)
-        
-    def Stop(self):
-        self.finishLock.acquire()
-        eg.MessageReceiver.Stop(self)


### PR DESCRIPTION
Windows 10 is a real fickle about having the same thread that registers for notifications also remove the notifications. in the case of the MainMesageReceiver it handled the ChangeClipboardChain which would remove EG from receiving clipboard notifications. if the process is not done right and the chain doesn't get repaired when EG closes other programs will stop receiving notifications that there is new or changed clipboard data. This moves the call to change the chain into the MainMessageReceiver thread so the clipboard chain get properly repaired when EG closes