### PR TITLE
Use consistent markup in the documentation

### DIFF
--- a/_build/data/docs/short_manual/index.rst
+++ b/_build/data/docs/short_manual/index.rst
@@ -104,17 +104,17 @@ There are three ways you can assign trigger Events to a Macro:
 #. Drag-and-drop an Event from the Log to an existing Macro in the 
    Configuration Tree.
 #. Select an Event in the Log and copy it to the clipboard using Ctrl+C, 
-   :menuselection:`Right-Click->Copy`, or :menuselection:`Edit->Copy`, then 
+   :menuselection:`Right-Click-->Copy`, or :menuselection:`Edit-->Copy`, then 
    select an existing Macro in the Configuration Tree and paste the Event 
-   using Ctrl+V, :menuselection:`Right-Click->Paste`, or 
-   :menuselection:`Edit->Paste`.
+   using Ctrl+V, :menuselection:`Right-Click-->Paste`, or 
+   :menuselection:`Edit-->Paste`.
 #. Select an existing Macro in the Configuration Tree and then add a new Event 
    using :menuselection:`Right-Click-->Add Event`, 
    :menuselection:`Configuration-->Add Event` 
    or clicking the :guilabel:`Add Event` toolbar button. 
 
 You can rename any existing Event by selecting it and pressing F2, or 
-selecting :menuselection:`Right-Click->Rename` Item or 
+selecting :menuselection:`Right-Click-->Rename` Item or 
 :menuselection:`Configuration-->Rename Item`, and typing the new Event name. 
 
 

--- a/_build/data/docs/writing_plugins.rst
+++ b/_build/data/docs/writing_plugins.rst
@@ -343,8 +343,8 @@ Nearly all configuration dialogs follow the same scheme.
    to panel.sizer, but therefore you need more knowledge of wx.Sizers.)
 #. Then you call panel.Affirmed() in a loop. This method of the panel will 
    finish the setup of the dialog and display it to the user. If the user 
-   dismisses the dialog with the cancel button, this method will return False 
-   and you are done.
+   dismisses the dialog with the :guilabel:`Cancel` button, this method will 
+   return False and you are done.
 #. If panel.Affirmed() returns True, you have to return the current settings 
    the user has made through panel.SetResult(...). In this case we get the 
    current setting of the text box by using GetValue() on it. 
@@ -354,7 +354,7 @@ will find that if you reconfigure the plugin this text is already set. It will
 even survive if you save your EventGhost configuration and restart EventGhost.
 
 It is needed to use panel.Affirmed() and panel.SetResult(...) in a loop, 
-because the user might also use the :guilabel:`Apply button` and EventGhost 
+because the user might also use the :guilabel:`Apply` button and EventGhost 
 needs to know the current settings from the panel without dismissing it 
 completely.
 


### PR DESCRIPTION
Just some minor markup fixes in the "Short Manual" and "Writing Plugins" documentation pages.