### PR TITLE
Add blank line after line block in eg.WindowsVersion docstring

### DIFF
--- a/eg/Classes/WindowsVersion.py
+++ b/eg/Classes/WindowsVersion.py
@@ -122,6 +122,7 @@ class WindowsVersion:
     +-----------+--------------------------------------+
 
     |
+
     .. The above line gives some extra space after the table in the helpfile.
        References:
            https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx


### PR DESCRIPTION
The lack of a blank line after the line block was causing the build warning:
```
C:\projects\eventghost\eg\Classes\WindowsVersion.py:docstring of eg.WindowsVersion:46: WARNING: Line block ends without a blank line.
```
https://ci.appveyor.com/project/topic2k/eventghost/build/554-master#L155