### PR TITLE
[USBUIRT] Fixes learn ir dialog not closing

### DIFF
--- a/plugins/USB-UIRT/__init__.py
+++ b/plugins/USB-UIRT/__init__.py
@@ -691,6 +691,7 @@ class IRLearnDialog(eg.Dialog):
     def OnClose(self, event):
         self.AbortLearnThread()
         event.Skip()
+        self.Destroy()
 
 
     def OnCancel(self, event):


### PR DESCRIPTION
I have no means to test this. but when looking at the changes to the MCERemoteVista plugin that has this same issue I instituted the same changes.