### PR TITLE
NamedPipe: Fixes possible endless loop if -restart is used at the CLI

### DIFF
--- a/eg/Classes/Document.py
+++ b/eg/Classes/Document.py
@@ -129,6 +129,9 @@ class Document(object):
         else:
             return wx.ID_NO
 
+    def IsDirty(self):
+        return self.isDirty
+
     @eg.LogItWithReturn
     def Close(self):
         try:

--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -124,8 +124,9 @@ if args.isMain:
                     if NamedPipe.send_message('eg.document.IsDirty, ()'):
                         answer = ctypes.windll.user32.MessageBoxA(
                             0,
-                            'EventGhost cannot restart.        \n\n'
-                            'Save configuration changes?.      \n',
+                            'EventGhost cannot restart.             \n\n'
+                            'Configuration contains unsaved changes.\n'
+                            'Do you want to save before continuing? \n',
                             "EventGhost Restart Error",
                             3 | 40000
                         )
@@ -149,7 +150,8 @@ if args.isMain:
                     if not NamedPipe.send_message('eg.app.Exit, ()'):
                         ctypes.windll.user32.MessageBoxA(
                             0,
-                            'EventGhost cannot restart - unknown error.\n',
+                            'EventGhost cannot restart.             \n\n'
+                            'Unknown Error.                         \n',
                             "EventGhost Restart Error",
                             0 | 40000
                         )


### PR DESCRIPTION
Fixes the possibility of getting into an endless loop if the eg instance needs to be saved and -restart has been used

This change also added the ability to send back through the pipe any returned data