### PR TITLE
Typo - Text.py, Fixes typo in save dialog

### DIFF
--- a/eg/Classes/Text.py
+++ b/eg/Classes/Text.py
@@ -174,7 +174,7 @@ class Default:
 
         class SaveChanges:
             mesg = (
-                "Configuration contains unsaved changed.\n\n"
+                "Configuration contains unsaved changes.\n\n"
                 "Do you want to save before continuing?"
             )
             saveButton = "&Save"


### PR DESCRIPTION
In the save changes dialog there was a typo this corrects that typo