### PR TITLE
Moves initialization of python paths to the first thing that EG does

### DIFF
--- a/eg/Classes/FolderPath.py
+++ b/eg/Classes/FolderPath.py
@@ -16,8 +16,11 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
+from os.path import join, split
 from ctypes import c_int, create_unicode_buffer, HRESULT, windll
 from ctypes.wintypes import DWORD, HANDLE, HWND, LPWSTR
+
+import eg
 
 GetTempPathW = windll.kernel32.GetTempPathW
 GetTempPathW.restype = DWORD
@@ -86,6 +89,62 @@ class FolderPath(object):
     __ALL__ = CSIDL.keys() + ["TemporaryFiles"]
     TemporaryFiles = temporaryFiles
     __repr__ = object.__repr__
+
+
+    @property
+    def mainDir(self):
+        return eg.Cli.PythonPaths.mainDir
+
+    @property
+    def configDir(self):
+        install_name = split(eg.Cli.PythonPaths.install_directory)[1]
+        config_dir = join(
+            self.RoamingAppData,
+            install_name
+        )
+
+        if eg.Cli.args.configDir and config_dir != eg.Cli.args.configDir:
+            config_dir = eg.Cli.args.configDir
+
+        return config_dir
+
+    @property
+    def corePluginDir(self):
+        return join(
+            self.mainDir,
+            "plugins"
+        )
+
+    @property
+    def localPluginDir(self):
+        if self.configDir == eg.Cli.args.configDir:
+            return self.corePluginDir
+
+        else:
+            install_name = split(eg.Cli.PythonPaths.install_directory)[1]
+            return join(
+                self.ProgramData,
+                install_name,
+                'plugins'
+            )
+
+    @property
+    def imagesDir(self):
+        return join(
+            self.mainDir,
+            "images"
+        )
+
+    @property
+    def languagesDir(self):
+        return join(
+            self.mainDir,
+            "languages"
+        )
+
+    @property
+    def sitePackagesDir(self):
+        return eg.Cli.PythonPaths.sitePackagesDir
 
     def __getattr__(self, name):
         csidl = CSIDL[name]

--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -26,13 +26,14 @@ import os
 import sys
 from os.path import abspath, dirname, join
 
+import PythonPaths
+
 ENCODING = locale.getdefaultlocale()[1]
 locale.setlocale(locale.LC_ALL, '')
 argvIter = (val.decode(ENCODING) for val in sys.argv)
 scriptPath = argvIter.next()
 
-# get program directory
-mainDir = abspath(join(dirname(__file__.decode('mbcs')), ".."))
+mainDir = PythonPaths.mainDir
 
 # determine the commandline parameters
 import __main__  # NOQA

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -59,7 +59,9 @@ eg.CORE_PLUGIN_GUIDS = (
 
 
 eg.namedPipe = NamedPipe.Server()
-eg.namedPipe.start()
+
+if eg.Cli.args.isMain:
+    eg.namedPipe.start()
 
 eg.ID_TEST = wx.NewId()
 eg.mainDir = eg.Cli.mainDir

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -47,6 +47,8 @@ import eg
 import Init
 import NamedPipe
 
+Init.InitPathsAndBuiltins()
+
 eg.APP_NAME = "EventGhost"
 eg.CORE_PLUGIN_GUIDS = (
     "{9D499A2C-72B6-40B0-8C8C-995831B10BB4}",  # "EventGhost"
@@ -55,18 +57,13 @@ eg.CORE_PLUGIN_GUIDS = (
     "{6B1751BF-F94E-4260-AB7E-64C0693FD959}",  # "Mouse"
 )
 
+
 eg.namedPipe = NamedPipe.Server()
 eg.namedPipe.start()
 
 eg.ID_TEST = wx.NewId()
 eg.mainDir = eg.Cli.mainDir
-eg.imagesDir = join(eg.mainDir, "images")
-eg.languagesDir = join(eg.mainDir, "languages")
-eg.sitePackagesDir = join(
-    eg.mainDir,
-    "lib%d%d" % sys.version_info[:2],
-    "site-packages"
-)
+
 eg.revision = 2000  # Deprecated
 eg.startupArguments = eg.Cli.args
 eg.debugLevel = eg.startupArguments.debugLevel
@@ -91,7 +88,6 @@ eg.lastFoundWindows = []
 eg.currentItem = None
 eg.actionGroup = eg.Bunch()
 eg.actionGroup.items = []
-eg.folderPath = eg.FolderPath()
 eg.GUID = eg.GUID()
 
 def _CommandEvent():
@@ -121,24 +117,6 @@ eg.ValueChangedEvent, eg.EVT_VALUE_CHANGED = eg.CommandEvent()
 eg.pyCrustFrame = None
 eg.dummyAsyncoreDispatcher = None
 
-if eg.startupArguments.configDir is None:
-    eg.configDir = join(eg.folderPath.RoamingAppData, eg.APP_NAME)
-else:
-    eg.configDir = eg.startupArguments.configDir
-if not exists(eg.configDir):
-    try:
-        os.makedirs(eg.configDir)
-    except:
-        pass
-if eg.startupArguments.isMain:
-    if exists(eg.configDir):
-        os.chdir(eg.configDir)
-    else:
-        os.chdir(eg.mainDir)
-eg.localPluginDir = join(eg.folderPath.ProgramData, eg.APP_NAME, "plugins")
-eg.corePluginDir = join(eg.mainDir, "plugins")
-eg.pluginDirs = [eg.corePluginDir, eg.localPluginDir]
-Init.InitPathsAndBuiltins()
 from eg.WinApi.Dynamic import GetCurrentProcessId  # NOQA
 eg.processId = GetCurrentProcessId()
 Init.InitPil()

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -147,16 +147,17 @@ def InitPathsAndBuiltins():
     eg.languagesDir = eg.folderPath.languagesDir
     eg.sitePackagesDir = eg.folderPath.sitePackagesDir
 
+    if not exists(eg.configDir):
+        try:
+            os.makedirs(eg.configDir)
+        except:
+            pass
 
-    try:
-        makedirs(eg.localPluginDir)
-    except:
-        eg.localPluginDir = ''
-
-    try:
-        makedirs(eg.configDir)
-    except:
-        pass
+    if not exists(eg.localPluginDir):
+        try:
+            makedirs(eg.localPluginDir)
+        except:
+            eg.localPluginDir = eg.corePluginDir
 
     if eg.Cli.args.isMain:
         if exists(eg.configDir):

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -147,21 +147,21 @@ def InitPathsAndBuiltins():
     eg.languagesDir = eg.folderPath.languagesDir
     eg.sitePackagesDir = eg.folderPath.sitePackagesDir
 
-    if eg.Cli.args.isMain:
-        if not exists(eg.localPluginDir):
-            try:
-                makedirs(eg.localPluginDir)
-            except:
-                eg.localPluginDir = ''
 
-        if exists(eg.configDir):
-            chdir(eg.configDir)
-        else:
-            try:
-                makedirs(eg.configDir)
-                chdir(eg.configDir)
-            except:
-                chdir(eg.mainDir)
+    try:
+        makedirs(eg.localPluginDir)
+    except:
+        eg.localPluginDir = ''
+
+    try:
+        makedirs(eg.configDir)
+    except:
+        pass
+
+    if eg.Cli.args.isMain and exists(eg.configDir):
+        chdir(eg.configDir)
+    elif eg.Cli.args.isMain:
+        chdir(eg.mainDir)
 
     __builtin__.wx = wx
 

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -158,10 +158,11 @@ def InitPathsAndBuiltins():
     except:
         pass
 
-    if eg.Cli.args.isMain and exists(eg.configDir):
-        chdir(eg.configDir)
-    elif eg.Cli.args.isMain:
-        chdir(eg.mainDir)
+    if eg.Cli.args.isMain:
+        if exists(eg.configDir):
+            chdir(eg.configDir)
+        else:
+            chdir(eg.mainDir)
 
     __builtin__.wx = wx
 

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import site
 import sys
-import winreg
 import wx
 from ctypes import windll
 from time import gmtime
 from types import ModuleType
+from os import listdir, makedirs, chdir
+from os.path import join, basename, isdir, exists, splitext
 
 # Local imports
 import eg
@@ -42,23 +41,23 @@ def DeInit():
         eg.dummyAsyncoreDispatcher.close()
 
 def ImportAll():
-    from os.path import join, basename
+
 
     def Traverse(root, moduleRoot):
-        for name in os.listdir(root):
+        for name in listdir(root):
             path = join(root, name)
-            if os.path.isdir(path):
+            if isdir(path):
                 name = basename(path)
                 if name in [".svn", ".git", ".idea"]:
                     continue
-                if not os.path.exists(join(path, "__init__.py")):
+                if not exists(join(path, "__init__.py")):
                     continue
                 moduleName = moduleRoot + "." + name
                 #print moduleName
                 __import__(moduleName)
                 Traverse(path, moduleName)
                 continue
-            base, ext = os.path.splitext(name)
+            base, ext = splitext(name)
             if ext != ".py":
                 continue
             if base == "__init__":
@@ -110,7 +109,7 @@ def InitGui():
     startupFile = eg.startupArguments.startupFile
     if startupFile is None:
         startupFile = config.autoloadFilePath
-    if startupFile and not os.path.exists(startupFile):
+    if startupFile and not exists(startupFile):
         eg.PrintError(eg.text.Error.FileNotFound % startupFile)
         startupFile = None
 
@@ -136,49 +135,48 @@ def InitGui():
     eg.Print(eg.text.MainFrame.Logger.welcomeText)
 
 def InitPathsAndBuiltins():
-    sys.path.insert(0, eg.mainDir.encode('mbcs'))
-    sys.path.insert(1, eg.sitePackagesDir.encode('mbcs'))
-
-    try:
-        if "PYTHONPATH" in os.environ:
-            for path in os.environ.get("PYTHONPATH").split(os.pathsep):
-                site.addsitedir(path)
-
-        key = winreg.HKEY_LOCAL_MACHINE
-        version = sys.version_info[:2]
-        subkey = r"SOFTWARE\Python\PythonCore\%d.%d\InstallPath" % version
-        with winreg.OpenKey(key, subkey) as hand:
-            site.addsitedir(
-                os.path.join(
-                    winreg.QueryValue(hand, None),
-                    "Lib",
-                    "site-packages",
-                )
-            )
-    except:
-        pass
-
     import cFunctions
-    sys.modules["eg.cFunctions"] = cFunctions
-    eg.cFunctions = cFunctions
-
-    # add 'wx' to the builtin name space of every module
     import __builtin__
+
+    eg.folderPath = eg.FolderPath()
+    eg.mainDir = eg.folderPath.mainDir
+    eg.configDir = eg.folderPath.configDir
+    eg.corePluginDir = eg.folderPath.corePluginDir
+    eg.localPluginDir = eg.folderPath.localPluginDir
+    eg.imagesDir = eg.folderPath.imagesDir
+    eg.languagesDir = eg.folderPath.languagesDir
+    eg.sitePackagesDir = eg.folderPath.sitePackagesDir
+
+    if eg.Cli.args.isMain:
+        if not exists(eg.localPluginDir):
+            try:
+                makedirs(eg.localPluginDir)
+            except:
+                eg.localPluginDir = ''
+
+        if exists(eg.configDir):
+            chdir(eg.configDir)
+        else:
+            try:
+                makedirs(eg.configDir)
+                chdir(eg.configDir)
+            except:
+                chdir(eg.mainDir)
+
     __builtin__.wx = wx
 
-    # we create a package 'PluginModule' and set its path to the plugin-dir
-    # so we can simply use __import__ to load a plugin file
     corePluginPackage = ModuleType("eg.CorePluginModule")
     corePluginPackage.__path__ = [eg.corePluginDir]
-    sys.modules["eg.CorePluginModule"] = corePluginPackage
-    eg.CorePluginModule = corePluginPackage
-    # we create a package 'PluginModule' and set its path to the plugin-dir
-    # so we can simply use __import__ to load a plugin file
-    if not os.path.exists(eg.localPluginDir):
-        os.makedirs(eg.localPluginDir)
     userPluginPackage = ModuleType("eg.UserPluginModule")
     userPluginPackage.__path__ = [eg.localPluginDir]
+
+    sys.modules["eg.CorePluginModule"] = corePluginPackage
     sys.modules["eg.UserPluginModule"] = userPluginPackage
+    sys.modules['eg.cFunctions'] = cFunctions
+
+    eg.pluginDirs = [eg.corePluginDir, eg.localPluginDir]
+    eg.cFunctions = cFunctions
+    eg.CorePluginModule = corePluginPackage
     eg.UserPluginModule = userPluginPackage
 
 def InitPil():

--- a/eg/PythonPaths.py
+++ b/eg/PythonPaths.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.org/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+
+import sys
+import os
+import site
+import winreg
+from types import ModuleType
+
+
+version = sys.version_info[:2]
+currentDir = os.path.dirname(__file__.decode('mbcs'))
+install_directory, folder_name = os.path.split(currentDir)
+
+while not folder_name:
+    install_directory, folder_name = os.path.split(install_directory)
+
+mainDir = os.path.abspath(install_directory)
+sitePackagesDir = os.path.join(
+    mainDir,
+    "lib%d%d" % version,
+    "site-packages"
+)
+
+sys.path.insert(0, mainDir.encode('mbcs'))
+sys.path.insert(1, sitePackagesDir.encode('mbcs'))
+
+try:
+    if "PYTHONPATH" in os.environ:
+        for path in os.environ.get("PYTHONPATH").split(os.pathsep):
+            site.addsitedir(path)
+
+    key = winreg.HKEY_LOCAL_MACHINE
+
+    subkey = r"SOFTWARE\Python\PythonCore\%d.%d\InstallPath" % version
+    with winreg.OpenKey(key, subkey) as hand:
+        site.addsitedir(
+            os.path.join(
+                winreg.QueryValue(hand, None),
+                "Lib",
+                "site-packages",
+            )
+        )
+except:
+    pass

--- a/eg/PythonPaths.py
+++ b/eg/PythonPaths.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 #
 # This file is part of EventGhost.
 # Copyright © 2005-2016 EventGhost Project <http://www.eventghost.org/>

--- a/eg/WinApi/PipedProcess.py
+++ b/eg/WinApi/PipedProcess.py
@@ -183,12 +183,13 @@ def GetUncPathOf(filePath):
         print "GetUncPathOf Error:", err, FormatError(err)
     return filePath
 
-if eg.debugLevel:
-    def Msg(msg):
-        print msg
-else:
-    def Msg(dummyMsg):
+
+def Msg(msg):
+    try:
+        eg.PrintDebugNotice(str(msg))
+    except:
         pass
+
 
 def RunAs(filePath, asAdministrator, *args):
     sei = SHELLEXECUTEINFO()

--- a/eg/WinApi/Utils.py
+++ b/eg/WinApi/Utils.py
@@ -26,7 +26,7 @@ from win32com.client import GetObject
 # Local imports
 import eg
 import Dynamic
-from eg.cFunctions import GetProcessName, GetWindowChildsList
+from cFunctions import GetProcessName, GetWindowChildsList
 from Dynamic import (
     # ctypes stuff
     byref, sizeof, WinError, _kernel32,


### PR DESCRIPTION
By moving the initialization of the python paths to the very startup of EG this allows for us to be able to import WinApi modules early on in the startup process without encountering an import exception for cFunctions

