### PR TITLE
[System] Fix Monitor On action not functioning properly in Windows > 8

### DIFF
--- a/plugins/System/__init__.py
+++ b/plugins/System/__init__.py
@@ -94,6 +94,7 @@ eg.RegisterPlugin(
 )
 
 ACV = wx.ALIGN_CENTER_VERTICAL
+MOUSEEVENTF_MOVE = 0x0001
 
 oldGetDeviceId = SoundMixer.GetDeviceId
 def GetDeviceId_(*args, **kwargs):
@@ -116,14 +117,16 @@ MONITOR_STATES = dict(
     ON=-1
 )
 
-
 def MonitorState(state):
-    win32gui.SendMessage(
-        win32con.HWND_BROADCAST,
-        win32con.WM_SYSCOMMAND,
-        SC_MONITORPOWER,
-        MONITOR_STATES[state]
-    )
+    if state == 'ON':
+        ctypes.windll.user32.mouse_event(MOUSEEVENTF_MOVE, 0, 1, 0, 0)
+    else:
+        win32gui.SendMessage(
+            win32con.HWND_BROADCAST,
+            win32con.WM_SYSCOMMAND,
+            SC_MONITORPOWER,
+            MONITOR_STATES[state]
+        )
 
 
 class Text:


### PR DESCRIPTION
Microsoft strikes again. they broke 

    SendMessage(HWND_BROADCAST, WM_SYSCOMMAND, SC_MONITORPOWER, -1) 

sometime between Windows 7 and Windows 8 and it has not been fixed still to this day. So I used moving the mouse one pixel to turn the monitors back on.

it is noted here about the Microsoft breakage

    https://stackoverflow.com/questions/25011141/turn-off-on-monitor-cant-turn-on

Do not merge this yet as I am waiting for an answer on whether or not it fixed it.