### PR TITLE
CLI: fix bug when showing message on -netsend failure

### DIFF
--- a/eg/Classes/NetworkSend.py
+++ b/eg/Classes/NetworkSend.py
@@ -23,6 +23,17 @@ from hashlib import md5
 
 ENCODING = locale.getdefaultlocale()[1]
 
+
+def ShowError(msg):
+    app = wx.PyApp()
+    wx.MessageBox(
+        message=msg,
+        caption="EventGhost - warning",
+        style=wx.ICON_EXCLAMATION | wx.OK,
+        parent=None
+    )
+
+
 def NetworkSend(host, port, password, eventString, payload=None):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -32,12 +43,10 @@ def NetworkSend(host, port, password, eventString, payload=None):
             sock.connect((host, port))
         except Exception, e:
             if e[0] == 10061:
-                wx.PySimpleApp()
-                wx.MessageBox(
-                    '%s.\n\nMaybe the destination computer has not installed\nthe plugin "Network event receiver" ?' % e[1],
-                    caption = "EventGhost - warning",
-                    style=wx.ICON_EXCLAMATION | wx.OK,
-                    parent = None
+                ShowError(
+                    '%s.\n\n'
+                    'Maybe the destination computer has not installed\n'
+                    'the plugin "Network event receiver" ?\n' % e[1]
                 )
             sock.close()
             return False
@@ -95,9 +104,25 @@ def NetworkSend(host, port, password, eventString, payload=None):
     return True
 
 def Main(argv):
-    host, port = argv[0].split(":")
-    password = argv[1]
-    eventstring = argv[2]
+    try:
+        host, port = argv[0].split(":")
+    except ValueError:
+        ShowError(
+            "Missing Port number.\n\n"
+            "EventGhost.exe -netsend <host>:<port> <password> "
+            "<eventname> [<payload> ...]"
+        )
+        exit(1)
+    try:
+        password = argv[1]
+        eventstring = argv[2]
+    except IndexError:
+        ShowError(
+            "Not enough parameters.\n\n"
+            "EventGhost.exe -netsend <host>:<port> <password> "
+            "<eventname> [<payload> ...]"
+        )
+        exit(1)
     payloads = argv[3:]
     NetworkSend(host, int(port), password, eventstring, payloads)
 

--- a/eg/Classes/NetworkSend.py
+++ b/eg/Classes/NetworkSend.py
@@ -18,21 +18,20 @@
 
 import locale
 import socket
-import wx
 from hashlib import md5
 
 ENCODING = locale.getdefaultlocale()[1]
 
 
 def ShowError(msg):
-    app = wx.PyApp()
-    wx.MessageBox(
-        message=msg,
-        caption="EventGhost - warning",
-        style=wx.ICON_EXCLAMATION | wx.OK,
-        parent=None
-    )
+    import ctypes
 
+    ctypes.windll.user32.MessageBoxA(
+        0,
+        msg,
+        "EventGhost - warning",
+        0 | 40000
+    )
 
 def NetworkSend(host, port, password, eventString, payload=None):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/eg/Classes/NetworkSend.py
+++ b/eg/Classes/NetworkSend.py
@@ -106,6 +106,9 @@ def NetworkSend(host, port, password, eventString, payload=None):
 def Main(argv):
     try:
         host, port = argv[0].split(":")
+        password = argv[1]
+        eventstring = argv[2]
+        payloads = argv[3:]
     except ValueError:
         ShowError(
             "Missing Port number.\n\n"
@@ -113,9 +116,6 @@ def Main(argv):
             "<eventname> [<payload> ...]"
         )
         exit(1)
-    try:
-        password = argv[1]
-        eventstring = argv[2]
     except IndexError:
         ShowError(
             "Not enough parameters.\n\n"
@@ -123,8 +123,8 @@ def Main(argv):
             "<eventname> [<payload> ...]"
         )
         exit(1)
-    payloads = argv[3:]
-    NetworkSend(host, int(port), password, eventstring, payloads)
+    else:
+        NetworkSend(host, int(port), password, eventstring, payloads)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Fix bug when showing message on send failure.
Avoid exception and show a message when not enough parameters were given.