### PR TITLE
Changes XmlIdLink to eg.GUID (see comment for more info)

### DIFF
--- a/eg/Classes/AddPluginDialog.py
+++ b/eg/Classes/AddPluginDialog.py
@@ -261,7 +261,10 @@ class AddPluginDialog(eg.TaskletDialog):
                     self.click_count = 0
                     dialog = eg.MessageDialog(
                         parent=None,
-                        message='Enable using GUID\'s?\n\n',
+                        message=(
+                            'Warning: This will save all EventGhost Data!!\n\n'
+                            'Enable using GUID\'s?\n\n'
+                        ),
                         style=wx.YES_NO | wx.STAY_ON_TOP
                     )
                     if dialog.ShowModal() == wx.ID_YES:
@@ -269,6 +272,10 @@ class AddPluginDialog(eg.TaskletDialog):
                     else:
                         setattr(eg.config, 'useTreeItemGUID', False)
                     dialog.Destroy()
+
+                    eg.document.SetIsDirty(True)
+                    eg.document.Save()
+                    eg.Config.Save()
 
             evt.Skip()
 

--- a/eg/Classes/AddPluginDialog.py
+++ b/eg/Classes/AddPluginDialog.py
@@ -275,7 +275,7 @@ class AddPluginDialog(eg.TaskletDialog):
 
                     eg.document.SetIsDirty(True)
                     eg.document.Save()
-                    eg.Config.Save()
+                    eg.config.Save()
 
             evt.Skip()
 

--- a/eg/Classes/AddPluginDialog.py
+++ b/eg/Classes/AddPluginDialog.py
@@ -267,7 +267,7 @@ class AddPluginDialog(eg.TaskletDialog):
                     if dialog.ShowModal() == wx.ID_YES:
                         setattr(eg.config, 'useTreeItemGUID', True)
                     else:
-                        getattr(eg.config, 'useTreeItemGUID', False)
+                        setattr(eg.config, 'useTreeItemGUID', False)
                     dialog.Destroy()
 
             evt.Skip()

--- a/eg/Classes/AddPluginDialog.py
+++ b/eg/Classes/AddPluginDialog.py
@@ -221,6 +221,62 @@ class AddPluginDialog(eg.TaskletDialog):
         treeCtrl.Bind(wx.EVT_TREE_ITEM_ACTIVATED, self.OnItemActivated)
         treeCtrl.SelectItem(itemToSelect)
 
+
+# -------- This code is for setting the use GUID instead of XmlIdLink ---------
+        self.click_count = 0
+
+        def on_left_down(evt):
+            x, y = evt.GetPosition()
+            width, height = self.GetClientSize()
+
+            start_x = width - 20
+            stary_y = 0
+
+            stop_x = start_x + 20
+            stop_y = stary_y + 20
+
+            if stop_x > x > start_x and stop_y > y > stary_y:
+                if not self.click_count:
+                    self.CaptureMouse()
+
+            start_x = 0
+            stary_y = height - 20
+
+            stop_x = start_x + 20
+            stop_y = stary_y + 20
+
+            if stop_x > x > start_x and stop_y > y > stary_y:
+                if self.click_count:
+                    self.CaptureMouse()
+
+            evt.Skip()
+
+        def on_left_up(evt):
+            if self.HasCapture():
+
+                self.ReleaseMouse()
+                self.click_count += 1
+
+                if self.click_count == 2:
+                    self.click_count = 0
+                    dialog = eg.MessageDialog(
+                        parent=None,
+                        message='Enable using GUID\'s?\n\n',
+                        style=wx.YES_NO | wx.STAY_ON_TOP
+                    )
+                    if dialog.ShowModal() == wx.ID_YES:
+                        setattr(eg.config, 'useTreeItemGUID', True)
+                    else:
+                        getattr(eg.config, 'useTreeItemGUID', False)
+                    dialog.Destroy()
+
+            evt.Skip()
+
+        self.Bind(wx.EVT_LEFT_DOWN, on_left_down)
+        self.Bind(wx.EVT_LEFT_UP, on_left_up)
+
+# -----------------------------------------------------------------------------
+
         while self.Affirmed():
             if self.CheckMultiload():
                 self.SetResult(self.resultData)

--- a/eg/Classes/AddPluginDialog.py
+++ b/eg/Classes/AddPluginDialog.py
@@ -262,25 +262,26 @@ class AddPluginDialog(eg.TaskletDialog):
                     dialog = eg.MessageDialog(
                         parent=None,
                         message=(
-                            'Warning: This will save all EventGhost Data!!\n\n'
+                            'Warning: This process cannot be undone so make\n'
+                            '                  a backup copy of your save file now.\n\n'
+                            'This process will modify and save all EventGhost Data!!\n'
                             'Enable using GUID\'s?\n\n'
                         ),
                         style=wx.YES_NO | wx.STAY_ON_TOP
                     )
                     if dialog.ShowModal() == wx.ID_YES:
-                        setattr(eg.config, 'useTreeItemGUID', True)
-                    else:
-                        setattr(eg.config, 'useTreeItemGUID', False)
-                    dialog.Destroy()
+                        eg.useTreeItemGUID = True
+                        eg.document.SetIsDirty(True)
+                        eg.document.Save()
+                        eg.config.Save()
 
-                    eg.document.SetIsDirty(True)
-                    eg.document.Save()
-                    eg.config.Save()
+                    dialog.Destroy()
 
             evt.Skip()
 
-        self.Bind(wx.EVT_LEFT_DOWN, on_left_down)
-        self.Bind(wx.EVT_LEFT_UP, on_left_up)
+        if eg.useTreeItemGUID is False:
+            self.Bind(wx.EVT_LEFT_DOWN, on_left_down)
+            self.Bind(wx.EVT_LEFT_UP, on_left_up)
 
 # -----------------------------------------------------------------------------
 

--- a/eg/Classes/GUID.py
+++ b/eg/Classes/GUID.py
@@ -78,12 +78,12 @@ class GUID(object):
     def AddId(self, target, guid):
         if guid in self.guidObjects:
             new = self.NewId(guid)
-            eg.PrintDebugMessage(
+            eg.PrintDebugNotice(
                 'GUID %r already exists, '
                 'New GUID: %r, '
                 'Existing Object: %r, '
                 'New Object: %s' %
-                (guid, new.guid, self.guidObjects[guid], target)
+                (guid, new.guid, self.guidObjects[guid].target, target)
             )
             return new
         else:
@@ -98,3 +98,4 @@ class GUID(object):
             return self.guidObjects[guid.guid]
         except KeyError:
             raise self.GuidException(guid)
+

--- a/eg/Classes/GUID.py
+++ b/eg/Classes/GUID.py
@@ -54,7 +54,19 @@ class GUIDBase(object):
         return self.target
 
 
+class GuidException(Exception):
+
+    def __init__(self, guid):
+        self.guid = guid
+
+    def __str__(self):
+        return 'No GUID %r exists' % self.guid
+
+
 class GUID(object):
+
+    GuidException = GuidException
+
     def __init__(self):
         self.guidObjects = {}
 
@@ -64,9 +76,20 @@ class GUID(object):
         return guid
 
     def AddId(self, target, guid):
-        guid = GUIDBase(target, guid)
-        self.guidObjects[guid.guid] = guid
-        return guid
+        if guid in self.guidObjects:
+            new = self.NewId(guid)
+            eg.PrintDebugMessage(
+                'GUID %r already exists, '
+                'New GUID: %r, '
+                'Existing Object: %r, '
+                'New Object: %s' %
+                (guid, new.guid, self.guidObjects[guid], target)
+            )
+            return new
+        else:
+            guid = GUIDBase(target, guid)
+            self.guidObjects[guid.guid] = guid
+            return guid
 
     def __call__(self, guid):
         if guid in self.guidObjects:
@@ -74,4 +97,4 @@ class GUID(object):
         try:
             return self.guidObjects[guid.guid]
         except KeyError:
-            raise AttributeError('%r has no attribute %r' % (self, guid))
+            raise self.GuidException(guid)

--- a/eg/Classes/GUID.py
+++ b/eg/Classes/GUID.py
@@ -78,14 +78,6 @@ class GUID(object):
     def AddId(self, target, guid):
         if guid in self.guidObjects:
             self.guidObjects[guid].target = target
-            # new = self.NewId(guid)
-            # eg.PrintDebugNotice(
-            #     'GUID %r already exists, '
-            #     'New GUID: %r, '
-            #     'Existing Object: %r, '
-            #     'New Object: %s' %
-            #     (guid, new.guid, self.guidObjects[guid].target, target)
-            # )
             return self.guidObjects[guid]
         else:
             guid = GUIDBase(target, guid)

--- a/eg/Classes/GUID.py
+++ b/eg/Classes/GUID.py
@@ -77,18 +77,19 @@ class GUID(object):
 
     def AddId(self, target, guid):
         if guid in self.guidObjects:
-            new = self.NewId(guid)
-            eg.PrintDebugNotice(
-                'GUID %r already exists, '
-                'New GUID: %r, '
-                'Existing Object: %r, '
-                'New Object: %s' %
-                (guid, new.guid, self.guidObjects[guid].target, target)
-            )
-            return new
+            self.guidObjects[guid].target = target
+            # new = self.NewId(guid)
+            # eg.PrintDebugNotice(
+            #     'GUID %r already exists, '
+            #     'New GUID: %r, '
+            #     'Existing Object: %r, '
+            #     'New Object: %s' %
+            #     (guid, new.guid, self.guidObjects[guid].target, target)
+            # )
+            return self.guidObjects[guid]
         else:
             guid = GUIDBase(target, guid)
-            self.guidObjects[guid.guid] = guid
+            self.guidObjects[str(guid)] = guid
             return guid
 
     def __call__(self, guid):
@@ -96,6 +97,9 @@ class GUID(object):
             return self.guidObjects[guid]
         try:
             return self.guidObjects[guid.guid]
+        except AttributeError:
+            guid = self.AddId(None, guid)
+            return guid
         except KeyError:
             raise self.GuidException(guid)
 

--- a/eg/Classes/TreeLink.py
+++ b/eg/Classes/TreeLink.py
@@ -48,6 +48,8 @@ class TreeLink(object):
 
     @classmethod
     def CreateFromArgument(cls, owner, xmlId):
+        if not isinstance(xmlId, int):
+            return xmlId
         self = TreeLink(owner)
         cls.linkList.append((self, xmlId))
         return self

--- a/eg/Classes/TreeLink.py
+++ b/eg/Classes/TreeLink.py
@@ -41,7 +41,10 @@ class TreeLink(object):
             pass
 
     def __repr__(self):
-        return repr(self.target.guid)
+        if hasattr(eg.config, 'useTreeItemGUID') and eg.config.useTreeItemGUID:
+            return repr(self.target.guid)
+        else:
+            return "XmlIdLink(%d)" % self.xmlId
 
     @classmethod
     def CreateFromArgument(cls, owner, xmlId):

--- a/eg/Classes/TreeLink.py
+++ b/eg/Classes/TreeLink.py
@@ -41,7 +41,7 @@ class TreeLink(object):
             pass
 
     def __repr__(self):
-        return "XmlIdLink(%d)" % self.xmlId
+        return repr(self.target.guid)
 
     @classmethod
     def CreateFromArgument(cls, owner, xmlId):

--- a/eg/Classes/TreeLink.py
+++ b/eg/Classes/TreeLink.py
@@ -41,7 +41,7 @@ class TreeLink(object):
             pass
 
     def __repr__(self):
-        if hasattr(eg.config, 'useTreeItemGUID') and eg.config.useTreeItemGUID:
+        if eg.useTreeItemGUID:
             return repr(self.target.guid)
         else:
             return "XmlIdLink(%d)" % self.xmlId
@@ -49,7 +49,9 @@ class TreeLink(object):
     @classmethod
     def CreateFromArgument(cls, owner, xmlId):
         if not isinstance(xmlId, int):
+            eg.useTreeItemGUID = True
             return xmlId
+
         self = TreeLink(owner)
         cls.linkList.append((self, xmlId))
         return self

--- a/eg/Classes/UndoHandler/Paste.py
+++ b/eg/Classes/UndoHandler/Paste.py
@@ -108,7 +108,6 @@ class Paste(UndoHandlerBase):
                 if pos + 1 == len(before.parent.childs):
                     pos = -1
             newNode = childCls(selection, childXmlNode)
-            newNode.guid = eg.GUID.NewId(newNode)
             newNode.RestoreState()
             selection.AddChild(newNode, pos)
             self.items.append(eg.TreePosition(newNode))

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -48,7 +48,7 @@ import Init
 import NamedPipe
 
 
-useTreeItemGUID = False
+eg.useTreeItemGUID = False
 
 Init.InitPathsAndBuiltins()
 

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -47,6 +47,9 @@ import eg
 import Init
 import NamedPipe
 
+
+useTreeItemGUID = False
+
 Init.InitPathsAndBuiltins()
 
 eg.APP_NAME = "EventGhost"


### PR DESCRIPTION
Please do test this with care. it is a pretty substantial change. but copying and pasting, backwards compatibility, saving, loading, pretty much anything that has to deal with XML or any of the actions that used XmlIdLink. this removes XmlIdLink from being issued anymore. all of the bits pertaining to it as far as being able to use it are still in place for backwards compatibility. But everything at this point will not create the XmlIdLink command anymore.

Removes the use of XmlIdLink in favor of eg.GUID.

We added the use of GUID's to the tree items but the use of XmlIdLink still halted the easy use of disable and enable actions from a python script and it also used the XmlIdLink when saving or copying of XML this caused an issue with being able to share xml code if it contained one of the actions that made use of the XmlIdLink.

To turn it on you would open the add plugin dialog and left click once in the upper right hand corner of the dialog (client area) and then click once in the lower left hand corner of the dialog (client area) there is a 20x20 pixel target for each of the spots so the cance of someone doing this accidentally is probably not going to happen. But in the event it does a message box asking if you want to enable or disable it pops up.