### PR TITLE
Disable the OK button in configure dialogs on first appearance

### DIFF
--- a/eg/Classes/ButtonRow.py
+++ b/eg/Classes/ButtonRow.py
@@ -109,8 +109,6 @@ class ButtonRow(object):
         self.numSpecialCtrls += 1
 
     def OnApply(self, event):
-        if hasattr(self, 'okButton'):
-            self.okButton.Enable(True)
         if hasattr(self.parent, "OnApply"):
             self.parent.OnApply(event)
         else:

--- a/eg/Classes/ButtonRow.py
+++ b/eg/Classes/ButtonRow.py
@@ -109,6 +109,8 @@ class ButtonRow(object):
         self.numSpecialCtrls += 1
 
     def OnApply(self, event):
+        if hasattr(self, 'okButton'):
+            self.okButton.Enable(True)
         if hasattr(self.parent, "OnApply"):
             self.parent.OnApply(event)
         else:

--- a/eg/Classes/ConfigPanel.py
+++ b/eg/Classes/ConfigPanel.py
@@ -52,6 +52,9 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
         self.resultCode = None
         self.buttonsEnabled = True
         self.dialog.buttonRow.applyButton.Enable(False)
+        self.dialog.buttonRow.okButton.Enable(
+            not self.dialog.treeItem.NeedsStartupConfiguration()
+        )
 
     def AddCtrl(self, ctrl):
         self.sizer.Add(ctrl, 0, wx.BOTTOM, 10)
@@ -120,6 +123,8 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
             buttonRow.applyButton.Enable(True)
         else:
             buttonRow.applyButton.Enable(False)
+            if self.dialog.treeItem.NeedsStartupConfiguration():
+                buttonRow.okButton.Enable(False)
 
     def FinishSetup(self):
         self.shown = True

--- a/eg/Classes/ConfigPanel.py
+++ b/eg/Classes/ConfigPanel.py
@@ -53,7 +53,7 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
         self.buttonsEnabled = True
         self.dialog.buttonRow.applyButton.Enable(False)
         self.dialog.buttonRow.okButton.Enable(
-            not self.dialog.treeItem.NeedsStartupConfiguration()
+            not self.dialog.treeItem.isFirstConfigure
         )
 
     def AddCtrl(self, ctrl):
@@ -123,8 +123,6 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
             buttonRow.applyButton.Enable(True)
         else:
             buttonRow.applyButton.Enable(False)
-            if self.dialog.treeItem.NeedsStartupConfiguration():
-                buttonRow.okButton.Enable(False)
 
     def FinishSetup(self):
         self.shown = True
@@ -158,6 +156,11 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
     @eg.LogIt
     def SetIsDirty(self, flag=True):
         self.isDirty = flag
+        if flag and self.dialog.treeItem.isFirstConfigure:
+            self.dialog.buttonRow.okButton.Enable(True)
+        elif self.dialog.treeItem.isFirstConfigure:
+            self.dialog.buttonRow.okButton.Enable(False)
+
         if flag and self.buttonsEnabled:
             self.dialog.buttonRow.applyButton.Enable(True)
 

--- a/eg/Classes/TreeItem.py
+++ b/eg/Classes/TreeItem.py
@@ -43,6 +43,7 @@ class TreeItem(object):
     childs = ()
     isDeactivatable = True
     isConfigurable = False
+    isFirstConfigure = False
     isRenameable = True
     isExecutable = False
     isMoveable = True
@@ -172,7 +173,6 @@ class TreeItem(object):
     def DropTest(self, dropNode):
         return self.dropBehaviour.get(dropNode.xmlTag, HINT_NO_DROP)
 
-    @eg.AssertInActionThread
     def Execute(self):
         return None, None
 

--- a/eg/Classes/UndoHandler/Configure.py
+++ b/eg/Classes/UndoHandler/Configure.py
@@ -31,6 +31,7 @@ class Configure(UndoHandlerBase):
         if item.openConfigDialog:
             item.openConfigDialog.Raise()
             return False
+        item.isFirstConfigure = isFirstConfigure
         ActionThreadFunc = eg.actionThread.Func
         self.oldArgumentString = ActionThreadFunc(item.GetArgumentString)()
         #oldArgs = newArgs = ActionThreadFunc(item.GetArguments)()


### PR DESCRIPTION
This will disable the OK button for plugin and action configure dialogs only when it is a new item added to the tree. it will enable the button once a setting change has been made. If the item being configure is one that was already present in the tree then the behavior is the same as it usually is.

This stops the user for inadvertently creating an "empty" or a non configured action