### PR TITLE
Use eg.APP_NAME instead of installation folder name for configDir

### DIFF
--- a/eg/Classes/FolderPath.py
+++ b/eg/Classes/FolderPath.py
@@ -120,10 +120,10 @@ class FolderPath(object):
             return self.corePluginDir
 
         else:
-            install_name = split(eg.Cli.PythonPaths.install_directory)[1]
+
             return join(
                 self.ProgramData,
-                install_name,
+                eg.APP_NAME,
                 'plugins'
             )
 

--- a/eg/Classes/FolderPath.py
+++ b/eg/Classes/FolderPath.py
@@ -97,10 +97,9 @@ class FolderPath(object):
 
     @property
     def configDir(self):
-        install_name = split(eg.Cli.PythonPaths.install_directory)[1]
         config_dir = join(
             self.RoamingAppData,
-            install_name
+            eg.APP_NAME
         )
 
         if eg.Cli.args.configDir and config_dir != eg.Cli.args.configDir:

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -52,7 +52,6 @@ eg.useTreeItemGUID = False
 
 Init.InitPathsAndBuiltins()
 
-eg.APP_NAME = "EventGhost"
 eg.CORE_PLUGIN_GUIDS = (
     "{9D499A2C-72B6-40B0-8C8C-995831B10BB4}",  # "EventGhost"
     "{A21F443B-221D-44E4-8596-E1ED7100E0A4}",  # "System"

--- a/eg/Init.py
+++ b/eg/Init.py
@@ -149,7 +149,7 @@ def InitPathsAndBuiltins():
 
     if not exists(eg.configDir):
         try:
-            os.makedirs(eg.configDir)
+            makedirs(eg.configDir)
         except:
             pass
 

--- a/eg/__init__.py
+++ b/eg/__init__.py
@@ -33,6 +33,9 @@ from Utils import *  # NOQA
 from Classes.WindowsVersion import WindowsVersion
 
 class DynamicModule(object):
+
+    APP_NAME = "EventGhost"
+    
     def __init__(self):
         mod = sys.modules[__name__]
         self.__dict__ = mod.__dict__


### PR DESCRIPTION
The creation of the config and programdata directories was changed to use the installation folder name. This was an accidental change but it has caused confusion (mainly with me) as to where to look for the config/plugins. there was also an error in it where the debugging log would still be written to the EventGhost config directory. so information was getting written all over the place. 