### PR TITLE
[EventGhost] - Enhancement - Remove setting the memory limits

### DIFF
--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -58,8 +58,6 @@ class Config(Section):
     hideOnStartup = False
     lastUpdateCheckDate = None
     lastUpdateCheckVersion = None
-    limitMemory = False
-    limitMemorySize = 8
     logActions = True
     logDebug = False
     logMacros = True

--- a/eg/Classes/EventThread.py
+++ b/eg/Classes/EventThread.py
@@ -49,20 +49,6 @@ class EventThread(ThreadWorker):
             self.filters[source] = [filterFunc]
 
     def Poll(self):
-        if eg.config.limitMemory and eg.document.frame is None:
-            try:
-                if 0 == SetProcessWorkingSetSize(
-                    self.hHandle,
-                    3670016,
-                    eg.config.limitMemorySize * 1048576
-                ):
-                    #TODO: what to do here?
-                    eg.PrintDebugNotice(FormatError())
-                    self.__class__.Poll = self.Poll2
-            except:
-                self.__class__.Poll = self.Poll2
-
-    def Poll2(self):
         pass
 
     def RemoveFilter(self, source, filterFunc):

--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -40,8 +40,6 @@ class Text(eg.TranslatableStrings):
     HideOnClose = "Keep running in background when window closed"
     HideOnStartup = "Hide on startup"
     LanguageGroup = "Language"
-    limitMemory1 = "Limit memory consumption while minimized to"
-    limitMemory2 = "MB"
     propResize = "Resize window proportionally"
     refreshEnv = 'Refresh environment before executing "Run" actions'
     showTrayIcon = "Display EventGhost icon in system tray"
@@ -113,18 +111,6 @@ class OptionsDialog(eg.TaskletDialog):
             text.HideOnClose
         )
 
-        memoryLimitCtrl = page1.CheckBox(config.limitMemory, text.limitMemory1)
-        memoryLimitSpinCtrl = page1.SpinIntCtrl(
-            config.limitMemorySize,
-            min=4,
-            max=999
-        )
-
-        def OnMemoryLimitCheckBox(dummyEvent):
-            memoryLimitSpinCtrl.Enable(memoryLimitCtrl.IsChecked())
-        memoryLimitCtrl.Bind(wx.EVT_CHECKBOX, OnMemoryLimitCheckBox)
-        OnMemoryLimitCheckBox(None)
-
         refreshEnvCtrl = page1.CheckBox(
             config.refreshEnv,
             text.refreshEnv
@@ -162,11 +148,6 @@ class OptionsDialog(eg.TaskletDialog):
         # construction of the layout with sizers
 
         flags = wx.ALIGN_CENTER_VERTICAL
-        memoryLimitSizer = eg.HBoxSizer(
-            (memoryLimitCtrl, 0, flags),
-            (memoryLimitSpinCtrl, 0, flags),
-            (page1.StaticText(text.limitMemory2), 0, flags | wx.LEFT, 2),
-        )
 
         startGroupSizer = wx.GridSizer(cols=1, vgap=2, hgap=2)
         startGroupSizer.AddMany(
@@ -177,7 +158,6 @@ class OptionsDialog(eg.TaskletDialog):
                 (confirmDeleteCtrl, 0, flags),
                 (showTrayIconCtrl, 0, flags),
                 (hideOnCloseCtrl, 0, flags),
-                (memoryLimitSizer, 0, flags),
                 (refreshEnvCtrl, 0, flags),
                 (propResizeCtrl, 0, flags),
                 (useFixedFontCtrl, 0, flags),
@@ -214,8 +194,6 @@ class OptionsDialog(eg.TaskletDialog):
             config.confirmDelete = confirmDeleteCtrl.GetValue()
             config.showTrayIcon = showTrayIconCtrl.GetValue()
             config.hideOnClose = hideOnCloseCtrl.GetValue()
-            config.limitMemory = bool(memoryLimitCtrl.GetValue())
-            config.limitMemorySize = memoryLimitSpinCtrl.GetValue()
             config.refreshEnv = refreshEnvCtrl.GetValue()
             config.propResize = propResizeCtrl.GetValue()
             config.useFixedFont = useFixedFontCtrl.GetValue()


### PR DESCRIPTION
This removes the setting of the memory limits when EG is minimized. there is really no use for this anymore because of the available memory in PC's these days. This was an old feature that was added when a computer had very limited amount of ram.