### PR TITLE
[EventGhost] - Enhancement - Adds options to stop EG from holding up a shutdown/restart

### DIFF
--- a/eg/Classes/App.py
+++ b/eg/Classes/App.py
@@ -164,6 +164,13 @@ class App(wx.App):
             self.shouldVeto = True
             event.Veto(True)
             ShutdownBlockReasonCreate(self.hwnd, "Unsaved data")
+            if eg.config.allowShutdown:
+                if eg.config.saveOnShutdown:
+                    eg.document.Save()
+                self.shouldVeto = False
+                ShutdownBlockReasonDestroy(self.hwnd)
+                wx.CallAfter(self.OnEndSession, None)
+                return
             res = eg.document.CheckFileNeedsSave()
             if res == wx.ID_YES:
                 # file was saved, reset everything
@@ -187,7 +194,11 @@ class App(wx.App):
         if not self.firstQuery:
             return
         self.firstQuery = False
-        if eg.document.CheckFileNeedsSave() == wx.ID_CANCEL:
+        if eg.config.allowShutdown:
+            if eg.config.saveOnShutdown:
+                eg.document.Save()
+            event.Veto()
+        elif eg.document.CheckFileNeedsSave() == wx.ID_CANCEL:
             event.Veto()
         wx.CallAfter(self.Reset)
 

--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -68,6 +68,8 @@ class Config(Section):
     refreshEnv = False
     showTrayIcon = True
     useFixedFont = False
+    saveOnShutdown = False
+    allowShutdown = False
 
     class plugins:  #pylint: disable-msg=C0103
         pass

--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -48,6 +48,8 @@ class Text(eg.TranslatableStrings):
     StartWithWindows = 'Autostart EventGhost for user "%s"' % os.environ["USERNAME"]
     UseAutoloadFile = "Autoload file"
     UseFixedFont = 'Use fixed-size font in the "Log" pane'
+    AllowShutdown = 'Do not stop a system shutdown/restart'
+    SaveOnShutdown = 'Save unsaved data on shutdown/restart'
 
 
 class OptionsDialog(eg.TaskletDialog):
@@ -140,6 +142,23 @@ class OptionsDialog(eg.TaskletDialog):
             text.UseFixedFont
         )
 
+        allowShutdownCtrl = page1.CheckBox(
+            config.allowShutdown,
+            text.AllowShutdown
+        )
+
+        saveOnShutdownCtrl = page1.CheckBox(
+            config.saveOnShutdown,
+            text.SaveOnShutdown
+        )
+
+        saveOnShutdownCtrl.Enable(config.allowShutdown)
+
+        def OnAllowShutdown(evt):
+            saveOnShutdownCtrl.Enable(evt.IsChecked())
+
+        allowShutdownCtrl.Bind(wx.EVT_CHECKBOX, OnAllowShutdown)
+
         def OnFixedFontBox(evt):
             self.UpdateFont(evt.IsChecked())
         useFixedFontCtrl.Bind(wx.EVT_CHECKBOX, OnFixedFontBox)
@@ -181,6 +200,8 @@ class OptionsDialog(eg.TaskletDialog):
                 (refreshEnvCtrl, 0, flags),
                 (propResizeCtrl, 0, flags),
                 (useFixedFontCtrl, 0, flags),
+                (allowShutdownCtrl, 0, flags),
+                (saveOnShutdownCtrl, 0, flags)
             )
         )
 
@@ -219,6 +240,8 @@ class OptionsDialog(eg.TaskletDialog):
             config.refreshEnv = refreshEnvCtrl.GetValue()
             config.propResize = propResizeCtrl.GetValue()
             config.useFixedFont = useFixedFontCtrl.GetValue()
+            config.allowShutdown = allowShutdownCtrl.GetValue()
+            config.saveOnShutdown = saveOnShutdownCtrl.GetValue()
             config.language = languageList[languageChoice.GetSelection()]
             config.Save()
             self.SetResult()


### PR DESCRIPTION
This adds an option to EG that the user can choose to enable which will allow a shutdown/restart to take place even if there is unsaved data. 

A second option has been added so that when the first is selected will cause any unsaved changes to be saved otherwise discard any unsaved data.

Not having this was a particular annoyance when some portion of a computer that was running EG because unresponsive and you needed to perform a remote shutdown/restart of the computer. if there was anything that was pending save in EG it would hang up the shutdown/restart of the computer