### PR TITLE
[EventGhost] - Enhancement - DesktopDisplay, convience module for display attributes

### DIFF
--- a/eg/Classes/DesktopDisplay.py
+++ b/eg/Classes/DesktopDisplay.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EventGhost.
+# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.net/>
+#
+# EventGhost is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# EventGhost is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with EventGhost. If not, see <http://www.gnu.org/licenses/>.
+
+
+import win32api
+import wx
+
+
+NID_INTEGRATED_TOUCH = 0x01
+NID_EXTERNAL_TOUCH = 0x02
+
+
+class BlackoutFrame(wx.Frame):
+
+    def __init__(self, handler):
+        self.handler = handler
+        wx.Frame.__init__(
+            self,
+            None,
+            -1,
+            style=wx.BORDER_NONE | wx.STAY_ON_TOP,
+            pos=(handler.x, handler.y),
+            size=(handler.w, handler.h)
+        )
+
+        self.Bind(wx.EVT_PAINT, self.OnPaint)
+        self.Show()
+
+    def OnPaint(self, evt=None):
+        try:
+            size = (self.handler.w, self.handler.h)
+            pos = (self.handler.x, self.handler.y)
+        except DisplayException:
+            self.handler.blackout = False
+            return
+
+        if self.GetSizeTuple() != size:
+            self.SetSize(size)
+
+        if self.GetPositionTuple() != pos:
+            self.SetPosition(pos)
+
+        bmp = wx.EmptyBitmap(*size)
+        dc = wx.MemoryDC()
+        dc.SelectObject(bmp)
+        dc.SetBackground(wx.Brush(wx.Colour(0, 0, 0)))
+        dc.Destroy()
+        del dc
+
+        if evt is not None:
+            dc = wx.PaintDC(self)
+            dc.DrawBitmap(bmp, 0, 0)
+
+
+class Display(object):
+
+    def __init__(self, idx):
+        self._idx = idx
+        self._frame = None
+
+    @property
+    def _handle(self):
+        displays = win32api.EnumDisplayMonitors()
+
+        if len(displays) - 1 >= self._idx:
+            return displays[self._idx][0]
+
+        if self._frame is not None:
+            self._frame.Destroy()
+            self._frame = None
+
+        raise DesktopDisplay.DisplayNumberError(self._idx)
+
+    @property
+    def blackout(self):
+        return self._frame is not None
+
+    @blackout.setter
+    def blackout(self, flag):
+        if flag and self._frame is None:
+            self._frame = BlackoutFrame(self)
+        elif not flag and self._frame:
+            self._frame.Destroy()
+            self._frame = None
+
+    @property
+    def x(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        return metrics['Monitor'][0]
+
+    @property
+    def y(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        return metrics['Monitor'][1]
+
+    @property
+    def w(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        return metrics['Monitor'][2] + -metrics['Monitor'][0]
+
+    @property
+    def h(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        return metrics['Monitor'][3] + -metrics['Monitor'][1]
+
+    @property
+    def primary(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        return bool(metrics['Flags'])
+
+    @property
+    def number(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        display = win32api.EnumDisplayDevices(metrics['Device'])
+        return int(display.DeviceName[4:].split('\\')[0][7:])
+
+    @property
+    def name(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        display = win32api.EnumDisplayDevices(metrics['Device'])
+        return display.DeviceString
+
+    @property
+    def size(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        w = metrics['Monitor'][2] + -metrics['Monitor'][0]
+        h = metrics['Monitor'][3] + -metrics['Monitor'][1]
+        return w, h
+
+    @property
+    def pos(self):
+        metrics = win32api.GetMonitorInfo(self._handle)
+        x = metrics['Monitor'][0]
+        y = metrics['Monitor'][1]
+        return x, y
+
+    def __str__(self):
+        return (
+            'Name: {0}, '
+            'Number: {1}, '
+            'Width: {2}, '
+            'Height: {3}, '
+            'X: {4}, '
+            'Y: {5}, '
+            'Primary: {6}'.format(
+                self.name,
+                self.number,
+                self.w,
+                self.h,
+                self.x,
+                self.y,
+                self.primary
+            )
+        )
+
+
+class DisplayException(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return str(self.msg)
+
+
+class DesktopDisplay(object):
+
+    DisplayException = DisplayException
+    Display = Display
+
+    class DisplayNameError(DisplayException):
+        pass
+
+
+    class DisplayNumberError(DisplayException):
+        pass
+
+
+    def __init__(self):
+        self._displays = []
+        self.Refresh()
+
+    def Refresh(self):
+        displays = []
+
+        for i, display_handles in enumerate(win32api.EnumDisplayMonitors()):
+            metrics = win32api.GetMonitorInfo(display_handles[0])
+            display = win32api.EnumDisplayDevices(metrics['Device'])
+            try:
+                if self._displays[i]['key'] != display.DeviceKey:
+                    if self._displays[i]['display'].blackout:
+                        self._displays[i]['display'].blackout = False
+
+                self._displays[i]['key'] = display.DeviceKey
+                displays += [self._displays[i]]
+
+            except IndexError:
+                displays += [dict(key=display.DeviceKey, display=Display(i))]
+        for display_data in self._displays[:]:
+            if display_data not in displays:
+                display = display_data['display']
+                if display.blackout:
+                    display.blackout = False
+
+                self._displays.remove(display_data)
+        self._displays = displays[:]
+
+    def EnumDisplays(self):
+        self.Refresh()
+        return list(display['display'] for display in self._displays)
+
+    def GetDisplay(self, display):
+        if isinstance(display, int):
+            number = display
+            name = None
+        else:
+            name = display
+            number = None
+
+        displays = self.EnumDisplays()
+        if name is not None:
+            for display in displays:
+                if display.name == name:
+                    return display
+            raise DesktopDisplay.DisplayNameError(name)
+        if number is not None:
+            if len(displays) - 1 >= number > -1:
+                return displays[number]
+            raise DesktopDisplay.DisplayNumberError(number)
+
+    @property
+    def size(self):
+        return win32api.GetSystemMetrics(78), win32api.GetSystemMetrics(79)
+
+    @property
+    def displayCount(self):
+        return win32api.GetSystemMetrics(80)
+
+    @property
+    def isTouchScreen(self):
+        try:
+            if win32api.GetSystemMetrics(86):
+                if eg.WindowsVersion >= 7:
+                    touch = win32api.GetSystemMetrics(94)
+                    if touch in (NID_INTEGRATED_TOUCH, NID_EXTERNAL_TOUCH):
+                        return True
+                    return False
+                return True
+        except:
+            pass
+        return False
+
+    @property
+    def isMultiTouch(self):
+        return self.maxTouchCount > 1
+
+    @property
+    def maxTouchCount(self):
+        if self.isTouchScreen:
+            return win32api.GetSystemMetrics(95)
+        else:
+            return 0
+
+    @property
+    def displays(self):
+        return self.EnumDisplays()
+
+DesktopDisplay = DesktopDisplay()

--- a/eg/Classes/DisplayChoice.py
+++ b/eg/Classes/DisplayChoice.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
-import wx
 
-# Local imports
 import eg
 
 class DisplayChoice(eg.Choice):
@@ -26,6 +24,14 @@ class DisplayChoice(eg.Choice):
     A wx.Choice control, that shows all available displays.
     """
     def __init__(self, parent, value, *args, **kwargs):
-        numDisplays = wx.Display().GetCount()
-        choices = ["Monitor %d" % (i + 1) for i in range(numDisplays)]
+        choices = list(
+            display.number + ': ' + display.name
+            for display in eg.DesktopDisplay.displays
+        )
         eg.Choice.__init__(self, parent, value, choices, *args, **kwargs)
+
+    def GetStringSelection(self):
+        return 'Monitor ' + str(self.GetSelection() + 1)
+
+    def GetDisplaySelection(self):
+        return eg.Choice.GetStringSelection(self).split(': ', 1)[1]


### PR DESCRIPTION
DesktopDisplay:
convience module for display attributes

methods:
Refresh() - refreshes the display list. this automatically gets called when EnumDisplays() or GetDisplay() is called.
EnumDisplays() - returns a list of displays
GetDisplay() - you can either pass this the monitor number or monitor name and this will return a DesktopDisplay.Display instance

attributes
displays - this is a list of all of the available displays that are attached
size - this is the virtual size of the desktop display
displayCount - number of connected displays
isTouchScreen - take a guess
isMultiTouch - take a guess
maxTouchCount - maximum number of simultaneous touches if the display is touch capable otherwise 0

DesktopDisplay.Display: 
this class will be returned as a representation of a specific display that is attached.

attributes:
blackout - set True/False to blackout the display
x - upper left corner of the display pixel position relative to the width of the desktop
y - upper left corner of the display pixel position relative to the height of the desktop
w - display pixel resolution width
h - display pixel resolution height
primary - True/False if the display is the primary display
number - display number, this the the number seen in the windows screen resolution dalog
name - nameof the display. this is the name seen in the screen resolution dialog
size - this is the size of the display returned as (w, h)
pos - this is the upper left corner pixel position of the display returned as (x, y)

If for example you have 3 displays attached and you disconnect display #2 this will automatically cause Windows to reorder the displays this will also reorder as required. 
If the screen is blacked out during this reordering it will remove the blackout.
If you change the display position when the screen is blacked out, the blackout should remain

Added 2 actions to the System plugin that will enable the blacking out of a specific monitor in a multi monitor arrangement. this is beneficial in the world of HTPC's because if you have a TV attached at the same time you were not able to shut off the monitor while leaving the TV on. this will not shut off the monitor either but at least it will make it less noticeable.

Changed eg.DisplayChoice  to list the display "number: display name" instead of "Monitor 1", "Monitor 2"
if you use GetStringSelection() it will return the usual "Monitor 1" this is for backwards compatibility with plugins. I have added GetDisplaySelection() to return the actual monitor name. This will not return the display "number: " that is seen in the list it will return only the display name

