### PR TITLE
Add Event before the loading of the plugins.

### DIFF
--- a/eg/Classes/AutostartItem.py
+++ b/eg/Classes/AutostartItem.py
@@ -38,7 +38,7 @@ class Time(object):
             t_fmt = t_fmt.format('th')
         else:
             t_fmt = t_fmt.format(
-                ["st", "nd", "rd"][t.tm_mday % 10 - 1]
+                ["st", "nd", "rd"][self.day % 10 - 1]
             )
         return self.strftime(t_fmt)
 

--- a/eg/Classes/AutostartItem.py
+++ b/eg/Classes/AutostartItem.py
@@ -20,6 +20,26 @@
 import eg
 from MacroItem import MacroItem
 from TreeItem import HINT_MOVE_INSIDE, HINT_MOVE_AFTER
+from datetime import datetime
+
+
+class Time(datetime):
+    def __init__(self):
+        super(Time, self).__init__(1, 1, 1)
+
+    def __str__(self):
+        t_fmt = '%A, %B %d{}, %Y @ %H:%M:%S %p'
+        if 4 <= self.day <= 20 or 24 <= self.day <= 30:
+            t_fmt = t_fmt.format('th')
+        else:
+            t_fmt = t_fmt.format(
+                ["st", "nd", "rd"][t.tm_mday % 10 - 1]
+            )
+        return self.strftime(t_fmt)
+
+    def __repr__(self):
+        return self.__str__()
+
 
 class AutostartItem(MacroItem):
     xmlTag = "Autostart"
@@ -68,6 +88,15 @@ class AutostartItem(MacroItem):
     def Enable(self, flag=True):
         # never disable the Autostart item
         pass
+
+    def Execute(self):
+        event = eg.EventGhostEvent(
+            prefix='EventGhost',
+            suffix='Startup',
+            payload=Time()
+        )
+        eg.actionThread.Func(event.Execute)()
+        MacroItem.Execute(self)
 
     @eg.LogIt
     @eg.AssertInActionThread

--- a/eg/Classes/AutostartItem.py
+++ b/eg/Classes/AutostartItem.py
@@ -23,9 +23,14 @@ from TreeItem import HINT_MOVE_INSIDE, HINT_MOVE_AFTER
 from datetime import datetime
 
 
-class Time(datetime):
+class Time(object):
+    _datetime = None
+
     def __init__(self):
-        super(Time, self).__init__(1, 1, 1)
+        self._datetime = datetime.now()
+
+    def __getattr__(self, item):
+        return getattr(self._datetime, item)
 
     def __str__(self):
         t_fmt = '%A, %B %d{}, %Y @ %H:%M:%S %p'
@@ -39,7 +44,6 @@ class Time(datetime):
 
     def __repr__(self):
         return self.__str__()
-
 
 class AutostartItem(MacroItem):
     xmlTag = "Autostart"
@@ -95,7 +99,7 @@ class AutostartItem(MacroItem):
             suffix='Startup',
             payload=Time()
         )
-        eg.actionThread.Func(event.Execute)()
+        event.Execute()
         MacroItem.Execute(self)
 
     @eg.LogIt


### PR DESCRIPTION
Adds  EventGhost.Startup event to take place before the running of the Autostart macro. This is done so that if the user needs to set into place any globals that a script may depend on it can be done before the possibility of a plugin starting and generating an event before the Main.OnInit gets triggered.

There is a payload with this event that is an instance of an AutostartItem.Time() object. I stored a  datetime.datetime object and it returns all methods/attributes correctly except __str__ and __repr__ methods so it would produce a nice date in the log.
example:    EventGhost.Startup Saturday, October 14th, 2017 @ 01:56:46 AM