### PR TITLE
Trigger event Windows.User.USERNAME on EventGhost start

### DIFF
--- a/eg/Classes/ActionThread.py
+++ b/eg/Classes/ActionThread.py
@@ -20,6 +20,7 @@ from time import clock
 
 # Local imports
 import eg
+from eg.WinApi import User
 
 EVENT_ICON_INDEX = eg.EventItem.icon.index
 
@@ -102,6 +103,20 @@ class ActionThread(eg.ThreadWorker):
                 print "   -", pluginInfo.name
             print "If you want to use them, please add the missing plugins."
 
+        payload = dict(
+            IsLocalAdmin=User.IsLocalAdmin(),
+            IsDomainLogin=User.IsDomainLogin()
+        )
+
+        if payload['IsDomainLogin']:
+            payload['IsDomainAdmin'] = User.IsDomainAdmin()
+
+        event = eg.EventGhostEvent(
+            prefix='EventGhost',
+            suffix='LoggedInUser.' + User.Name(),
+            payload=payload
+        )
+        event.Execute()
         eg.programCounter = (eg.document.autostartMacro, None)
         eg.RunProgram()
 

--- a/eg/Classes/ActionThread.py
+++ b/eg/Classes/ActionThread.py
@@ -112,8 +112,8 @@ class ActionThread(eg.ThreadWorker):
             payload['IsDomainAdmin'] = User.IsDomainAdmin()
 
         event = eg.EventGhostEvent(
-            prefix='EventGhost',
-            suffix='LoggedInUser.' + User.Name(),
+            prefix='Windows',
+            suffix='User.' + User.Name(),
             payload=payload
         )
         event.Execute()


### PR DESCRIPTION
Adds the event EventGhost.LoggedInUser.USERNAME on startup
This event is the first event hat will occur. This will allow for macros to be run depending on the username but also if they are administrator or not.

There is a payload that is a dict(IsLocalAdmin=bool, IsDomainLogin=bool, IsDomainAdmin=bool)
IsDomainAdmin will only be added if IsDomainLogin is true
example:    EventGhost.LoggedInUser.Administrator {'IsLocalAdmin': True, 'IsDomainLogin': False}