### PR TITLE
On save write config data to a buffer object before replacing config file

### DIFF
--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -19,6 +19,7 @@
 import os
 import sys
 from os.path import exists
+from cStringIO import StringIO
 from types import ClassType, InstanceType
 
 # Local imports
@@ -99,9 +100,10 @@ class Config(Section):
 
     def Save(self):
         self.version = eg.Version.string
-        configFile = open(self._configFilePath, 'w+')
-        RecursivePySave(self, configFile.write)
-        configFile.close()
+        config_data = StringIO()
+        RecursivePySave(self, config_data.write)
+        with open(self._configFilePath, 'w+') as config_file:
+            config_file.write(config_data.getvalue())
 
 
 def MakeSectionMetaClass(dummyName, dummyBases, dct):


### PR DESCRIPTION
There was an issue that was reported here
http://www.eventghost.net/forum/viewtopic.php?f=4&t=5908

It had to do with EG starting up with defaulted options. This problem occurred because EG was hanging during the process of gathering the config data to be written to the file. The way it had been set up before is the file would be opened in write mode, which would cause the file to be blank and then as the config options were processed they were written. So if an error occurred somewhere during this process you would end up with a deleted config file. 

I have substituted the opening of the file with the data being written to a cString.StringIO object instead. and after the data has been successfully transferred to that object then we open the config.py file and transfer the data form the StringIO object to the file. So now if an error occurs it will not create a blank config.py file.