### PR TITLE
[EventGhost] - Enhancement - Utils.EqualizeWidths, 

### DIFF
--- a/eg/Utils.py
+++ b/eg/Utils.py
@@ -258,10 +258,23 @@ def EnsureVisible(window):
     # set the new position and size
     window.SetRect((left, top, right - left, bottom - top))
 
-def EqualizeWidths(ctrls):
-    maxWidth = max((ctrl.GetBestSize()[0] for ctrl in ctrls))
-    for ctrl in ctrls:
-        ctrl.SetMinSize((maxWidth, -1))
+def EqualizeWidths(*args):
+
+    def iter_ctrls(ctrls):
+        maxWidth = -99
+        for ctrl in ctrls:
+            if isinstance(ctrl, (list, tuple)):
+                iter_ctrls(ctrl)
+                continue
+            else:
+                maxWidth = max((ctrl.GetBestSize()[0], maxWidth))
+
+        if maxWidth != -99:
+            for ctrl in ctrls:
+                if not isinstance(ctrl, (list, tuple)):
+                    ctrl.SetMinSize((maxWidth, -1))
+
+    iter_ctrls(args)
 
 def ExecFile(filename, globals=None, locals=None):
     """


### PR DESCRIPTION
eg.EqualizeWidths was coded to accept a single iterable of controls. I have found this very limiting.

So what I have done is it uses *args and you can pass single controls as positional areuments, or you can pass nested lists/tuples or a combination

These work exactly like before with no changes

    eg.EqualizeWidths(ctrl1, ctrl2, ctrl3, ctrl4)
    eg.EqualizeWidths((ctrl1, ctrl2, ctrl3, ctrl4))

below will set the widths the same for all of the controls in tuple 1. and then it will set the widths the same for tuple 2. tuple 1 will not have the same widths as tuple 2

    eg.EqualizeWidths((ctrl1, ctrl2, ctrl3, ctrl4), (ctrl5, ctrl6, ctrl7, ctrl8))

in the example below the tuples works the same as above but in this example you see ctrl1 and ctrl5 are not in a tuple. those 2 controls will have matching widths but they will not match the widths of tuple 1 or tuple 2

    eg.EqualizeWidths(ctrl1,(ctrl2, ctrl3, ctrl4), ctrl5, (ctrl6, ctrl7, ctrl8))

