### PR TITLE
[EventGhost] - Enhancement - ConfigPanel.py, Equalizes the widths of the StaticText controls when using AddLine

### DIFF
--- a/eg/Classes/ConfigPanel.py
+++ b/eg/Classes/ConfigPanel.py
@@ -65,6 +65,7 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
         sizer.SetFlexibleDirection(wx.HORIZONTAL)
         rowFlagsGet = self.rowFlags.get
         colFlagsGet = self.colFlags.get
+        text_ctrls = []
         for rowNum, (row, kwargs) in enumerate(grid):
             if kwargs.get("growable", False):
                 sizer.AddGrowableRow(rowNum)
@@ -78,8 +79,21 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
                 flags |= (wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_LEFT)
                 sizer.Add(ctrl, (rowNum, colNum), (1, 1), flags)
 
+                if (
+                    not colNum % 2
+                    and isinstance(ctrl, wx.StaticText)
+                    and len(row) - 1 > colNum
+                ):
+                    text_ctrls += [[]] * (colNum - len(text_ctrls) + 1)
+                    text_ctrls[colNum] += [ctrl]
+
             if colNum < columns - 1:
                 sizer.SetItemSpan(ctrl, (1, columns - colNum + 1))
+
+            for ctrls in text_ctrls:
+                if ctrls:
+                    eg.EqualizeWidths(tuple(ctrls))
+
         self.sizer.Add(sizer, 1, wx.EXPAND)
 
     def AddLabel(self, label):


### PR DESCRIPTION
When using the AddLine method of eg.ConfigPanel this causes the labels and controls to be rendered in a not so pleasing manner. I have added the equalizing of even numbered columns if the control is a wx.StaticText instance and if there are more column items in that specific row. it will add these instances into matching groups based on column number. and each grouping of controls then get passed to EqualizeWidths.

This produces a much nicer looking dialog. without messing up any description lines or help lines.

I am unsure if there are any use cases where this may cause an issue. I have not been able to locate one So be sure to test it if you know of a plugin that uses AddGrid or AddLine in an odd manner.

I could target this to be specific to AddLine. I would have to create the Controls if any text is present in the AddLine method instead of where they are currently created in the AddGrid method.
