### PR TITLE
Fix -event CLI option

### DIFF
--- a/eg/Classes/EventThread.py
+++ b/eg/Classes/EventThread.py
@@ -75,7 +75,7 @@ class EventThread(ThreadWorker):
         actionThread.Func(actionThread.StartSession, 120)(filename)
         self.TriggerEvent("OnInit")
         if self.startupEvent is not None:
-            self.TriggerEvent(*self.startupEvent)
+            self.TriggerEvent(self.startupEvent[0], self.startupEvent[1])
             self.startupEvent = None
 
     @eg.LogIt

--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -98,6 +98,20 @@ def send_message(msg, *msg_args):
 if args.isMain:
     for arg in argvIter:
         arg = arg.lower()
+
+        if arg in ('-e', '-event'):
+            eventstring = argvIter.next()
+            payloads = list()
+            for payload in argvIter:
+                if payload.startswith('-'):
+                    arg = payload
+                    break
+                payloads.append(payload)
+
+            if len(payloads) == 0:
+                payloads = None
+            args.startupEvent = (eventstring, payloads)
+
         if arg.startswith('-debug'):
             args.debugLevel = 1
             if len(arg) > 6:
@@ -120,12 +134,6 @@ if args.isMain:
             sys.exit(0)
         elif arg in ('-m', '-multiload'):
             args.allowMultiLoad = True
-        elif arg in ('-e', '-event'):
-            eventstring = argvIter.next()
-            payloads = list(argvIter)
-            if len(payloads) == 0:
-                payloads = None
-            args.startupEvent = (eventstring, payloads)
         elif arg in ('-f', '-file'):
             args.startupFile = abspath(argvIter.next())
         elif arg in ('-p', '-plugin'):
@@ -144,7 +152,6 @@ if args.isMain:
                 args.pluginFile = path
             elif ext in (".egtree", ".xml"):
                 args.startupFile = path
-
     if (
         not args.allowMultiLoad and
         not args.translate and

--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -121,8 +121,11 @@ if args.isMain:
         elif arg in ('-m', '-multiload'):
             args.allowMultiLoad = True
         elif arg in ('-e', '-event'):
-            args.startupEvent = tuple(argvIter)
-
+            eventstring = argvIter.next()
+            payloads = list(argvIter)
+            if len(payloads) == 0:
+                payloads = None
+            args.startupEvent = (eventstring, payloads)
         elif arg in ('-f', '-file'):
             args.startupFile = abspath(argvIter.next())
         elif arg in ('-p', '-plugin'):


### PR DESCRIPTION
The -event option were unintentional changed. The command `EventGhost.exe -e myevent with multiple payloads` generates the event `multiple.myevent` with payload `u"with"`. The correct (as in EG 0.4.r1722) event should be `Main.myevent` with payload `[u'with', u'multiple', u'payloads']`.