### PR TITLE
Bring EG to front if it's only hidden behind other windows

### DIFF
--- a/eg/Classes/TaskBarIcon.py
+++ b/eg/Classes/TaskBarIcon.py
@@ -81,6 +81,7 @@ class TaskBarIcon(wx.TaskBarIcon):
     def OnCmdShow(self, dummyEvent=None):
         if eg.mainFrame is not None:
             eg.mainFrame.Iconize(False)
+            eg.mainFrame.Raise()
         else:
             eg.document.ShowFrame()
 


### PR DESCRIPTION
Until now a click on 'show' in tray icon menu wouldn't show the EG window if it's only behind other windows and not minimized. This fix will also bring it to front in this case.