### PR TITLE
NamedPipe.py: Remove sending a ping through the pipe

### DIFF
--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -158,27 +158,22 @@ if args.isMain:
         args.isMain # and
         # not args.pluginFile
     ):
-        try:
-            if send_message('eg.namedPipe.ping') == 'pong':
-                if args.restart:
-                    restart()
-                else:
-                    if args.startupFile is not None:
-                        send_message('eg.document.Open', args.startupFile)
-                    if args.startupEvent is not None:
-                        send_message('eg.TriggerEvent', *args.startupEvent)
-                    if args.pluginFile:
-                        send_message(
-                            'eg.PluginInstall.Import',
-                            args.pluginFile
-                        )
-                    if args.hideOnStartup:
-                        send_message('eg.document.HideFrame')
-                    sys.exit(0)
+        if NamedPipe.is_eg_running:
+            if args.restart:
+                restart()
             else:
-                sys.exit(1)
-        except NamedPipe.NamedPipeConnectionError:
-            pass
+                if args.startupFile is not None:
+                    send_message('eg.document.Open', args.startupFile)
+                if args.startupEvent is not None:
+                    send_message('eg.TriggerEvent', *args.startupEvent)
+                if args.pluginFile:
+                    send_message(
+                        'eg.PluginInstall.Import',
+                        args.pluginFile
+                    )
+                if args.hideOnStartup:
+                    send_message('eg.document.HideFrame')
+                sys.exit(0)
 
         appMutex = ctypes.windll.kernel32.CreateMutexA(
             None,


### PR DESCRIPTION
removed the need to ping the named pipe to check the existence of an already running session of EG. This new method allows for faster loading times of EG. It is also less error prone. Another added benefit is PR #290 runs about a half a second faster when triggering 100 events from the command line.

This PR closes #291 