### PR TITLE
[requests] PythonPaths.py, Fixes SSL error

### DIFF
--- a/eg/PythonPaths.py
+++ b/eg/PythonPaths.py
@@ -41,6 +41,12 @@ sitePackagesDir = os.path.join(
 sys.path.insert(0, mainDir.encode('mbcs'))
 sys.path.insert(1, sitePackagesDir.encode('mbcs'))
 
+os.environ['REQUESTS_CA_BUNDLE'] = os.path.join(
+    sitePackagesDir,
+    'requests',
+    'cacert.pem'
+)
+
 try:
     if "PYTHONPATH" in os.environ:
         for path in os.environ.get("PYTHONPATH").split(os.pathsep):


### PR DESCRIPTION
Adds the environment variable REQUESTS_CA_BUNDLE which points to the requests/cacert.pem file. This should take care of an SSL error that comes up on some systems.

http://www.eventghost.net/forum/viewtopic.php?f=15&t=10066&p=50080#p50080

http://www.eventghost.net/forum/viewtopic.php?f=2&t=9725&start=15&sid=600e97c0d6743203ab78f4316b35917f

we should wait on merging this until it gets confirmed as a working solution.