### PR TITLE
add an option to show date in log (requested by Snowbird)

### DIFF
--- a/eg/Classes/Config.py
+++ b/eg/Classes/Config.py
@@ -54,6 +54,7 @@ class Config(Section):
     checkPreRelease = False
     colourPickerCustomColours = [(-1, -1, -1, 255) for n in range(16)]
     confirmDelete = True
+    datestamp = "%x"
     defaultThreadStartTimeout = 5.00
     hideOnClose = False
     hideOnStartup = False

--- a/eg/Classes/MainFrame/LogCtrl.py
+++ b/eg/Classes/MainFrame/LogCtrl.py
@@ -50,7 +50,7 @@ class LogCtrl(wx.ListCtrl):
         self.maxlength = 2000
         self.removeOnMax = 200
         self.indent = ""
-        self.OnGetItemText = self.OnGetItemTextWithTime
+        self.OnGetItemText = self.OnGetItemTextWithDT
         wx.ListCtrl.__init__(
             self,
             parent,
@@ -118,7 +118,9 @@ class LogCtrl(wx.ListCtrl):
         accel = wx.AcceleratorTable(accel_entries)
         self.SetAcceleratorTable(accel)
 
+        self.logDates = True
         self.logTimes = True
+        self._datetime_fmt = " %x  %X   "
         self.__inSelection = False
         self.isOdd = False
         self.data = collections.deque()
@@ -247,11 +249,10 @@ class LogCtrl(wx.ListCtrl):
         line, _, _, _, indent = self.data[item]
         return " " + indent * self.indent + line
 
-    def OnGetItemTextWithTime(self, item, dummyColumn):
+    def OnGetItemTextWithDT(self, item, dummyColumn):
         line, _, _, when, indent = self.data[item]
         return (
-            #strftime(" %X   ", localtime(when))
-            strftime(" %H:%M:%S   ", localtime(when)) +
+            strftime(self._datetime_fmt, localtime(when)) +
             indent * self.indent +
             line
         )
@@ -315,10 +316,24 @@ class LogCtrl(wx.ListCtrl):
             self.indent = ""
         self.Refresh()
 
+    def SetDateLogging(self, flag):
+        self.logDates = flag
+        self.SetDTLogging()
+
     def SetTimeLogging(self, flag):
         self.logTimes = flag
-        if flag:
-            self.OnGetItemText = self.OnGetItemTextWithTime
+        self.SetDTLogging()
+
+    def SetDTLogging(self):
+        if self.logDates and self.logTimes:
+            self._datetime_fmt = " %x  %X   "
+        elif self.logDates:
+            self._datetime_fmt = " %x   "
+        elif self.logTimes:
+            self._datetime_fmt = " %X   "
+
+        if self.logDates or self.logTimes:
+            self.OnGetItemText = self.OnGetItemTextWithDT
         else:
             self.OnGetItemText = self.OnGetItemTextNormal
         self.Refresh()

--- a/eg/Classes/MainFrame/LogCtrl.py
+++ b/eg/Classes/MainFrame/LogCtrl.py
@@ -120,7 +120,7 @@ class LogCtrl(wx.ListCtrl):
 
         self.logDates = True
         self.logTimes = True
-        self._datetime_fmt = " %x  %X   "
+        self._datetime_fmt = " {0}  %X   ".format(eg.config.datestamp)
         self.__inSelection = False
         self.isOdd = False
         self.data = collections.deque()
@@ -326,9 +326,9 @@ class LogCtrl(wx.ListCtrl):
 
     def SetDTLogging(self):
         if self.logDates and self.logTimes:
-            self._datetime_fmt = " %x  %X   "
+            self._datetime_fmt = " {0}  %X   ".format(eg.config.datestamp)
         elif self.logDates:
-            self._datetime_fmt = " %x   "
+            self._datetime_fmt = " {0}   ".format(eg.config.datestamp)
         elif self.logTimes:
             self._datetime_fmt = " %X   "
 

--- a/eg/Classes/MainFrame/__init__.py
+++ b/eg/Classes/MainFrame/__init__.py
@@ -64,6 +64,7 @@ class Config(eg.PersistentData):
     position = (50, 50)
     size = (700, 450)
     showToolbar = True
+    logDate = False
     logTime = False
     indentLog = True
     expandOnEvents = False
@@ -236,6 +237,8 @@ class MainFrame(wx.Frame):
     def CreateLogCtrl(self):
         logCtrl = LogCtrl(self)
         logCtrl.Freeze()
+        if not Config.logDate:
+            logCtrl.SetDateLogging(False)
         if not Config.logTime:
             logCtrl.SetTimeLogging(False)
         logCtrl.SetIndent(Config.indentLog)
@@ -325,6 +328,7 @@ class MainFrame(wx.Frame):
         Append("LogDebug", kind=wx.ITEM_CHECK).Check(eg.config.logDebug)
         menu.AppendSeparator()
         Append("IndentLog", kind=wx.ITEM_CHECK).Check(Config.indentLog)
+        Append("LogDate", kind=wx.ITEM_CHECK).Check(Config.logDate)
         Append("LogTime", kind=wx.ITEM_CHECK).Check(Config.logTime)
         menu.AppendSeparator()
         Append("ClearLog")
@@ -925,6 +929,11 @@ class MainFrame(wx.Frame):
         flag = self.menuBar.IsChecked(ID["LogTime"])
         Config.logTime = flag
         self.logCtrl.SetTimeLogging(flag)
+
+    def OnCmdLogDate(self):
+        flag = self.menuBar.IsChecked(ID["LogDate"])
+        Config.logDate = flag
+        self.logCtrl.SetDateLogging(flag)
 
     def OnCmdIndentLog(self):
         shouldIndent = self.menuBar.IsChecked(ID["IndentLog"])

--- a/eg/Classes/Text.py
+++ b/eg/Classes/Text.py
@@ -141,6 +141,7 @@ class Default:
             LogActions = "Log &Actions"
             LogDebug = "Log &Debug Info"
             IndentLog = "&Indent Log"
+            LogDate = "Datestam&p Log"
             LogTime = "Time&stamp Log"
             ClearLog = "Clear &Log"
 


### PR DESCRIPTION
This PR adds an option to the view menu to enable/disable a datestamp in the log window. The date format can be edited in the EventGhost options.

http://www.eventghost.net/forum/viewtopic.php?p=49079#p49079