### PR TITLE
Add exception catching to plugin close.

### DIFF
--- a/eg/Classes/PluginInstanceInfo.py
+++ b/eg/Classes/PluginInstanceInfo.py
@@ -51,7 +51,11 @@ class PluginInstanceInfo(PluginModuleInfo):
         if self.isStarted:
             self.Stop()
         if not self.initFailed:
-            self.instance.__close__()
+            try:
+                self.instance.__close__()
+            except:
+                import traceback
+                eg.PrintDebugNotice(traceback.format_exc())
 
     def CreateInstance(self, args, evalName, treeItem):
         self.args = args


### PR DESCRIPTION
This is so that EG doesn't get hung up forcing a user to terminate the
process potentially leading to things like orphaned ports. or files not
written to when EG closes (config.py)