### PR TITLE
[Eventghost] Enhancement Build, Updates the builder.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,15 +54,7 @@ install:
       "=============== prepare EventGhost build environment ==============="
       If (-not (Test-Path $PythonFolder))
       {
-        Function PipInstall ($msg, $mod)
-        {
-          " "
-          "--- " + $msg
-          "    Installing..."
-          pip install -q $mod
-          "    Done."
-        }
-        " "
+
         "--- Stackless 2.7.12150 x86"
         $StacklessInstaller = $InstallersFolder + "python-2.7.12150-stackless.msi"
         $StacklessInstallDir = "TARGETDIR=" + $PythonFolder
@@ -72,53 +64,7 @@ install:
         Start-Process MsiExec.exe -Arg "/I $StacklessInstaller /quiet /passive /qn /norestart $StacklessInstallDir" -Wait
         "    Done."
         " "
-        "--- wxPython 3.0.2.0"
-        $WXInstaller = $InstallersFolder + "wxPython3.0-win32-3.0.2.0-py27.exe"
-        $WXURL = "http://downloads.sourceforge.net/wxpython/wxPython3.0-win32-3.0.2.0-py27.exe"
-        Start-FileDownload $WXURL -Timeout 60000 -FileName $WXInstaller
-        "    Installing..."
-        Start-Process $WXInstaller -Arg "/VERYSILENT /SUPPRESSMSGBOXES" -NoNewWindow -Wait
-        "    Done."
-        " "
-        "--- pip 9.0.1"
-        "    Updating..."
-        python -m pip install -q -U "pip==9.0.1"
-        "    Done."
-        " "
-        "--- setuptools 34.3.0"
-        "    Updating..."
-        pip install -q -U "setuptools==34.3.0"
-        "    Done."
-        PipInstall "wheel 0.29.0" "wheel==0.29.0"
-        # sphinx >= 1.4.9 installs jinja2 >= 2.3 as dependency,
-        # jinja2 >= 2.9 has an async module which py2exe has
-        # problems with (build of eg will fail)
-        PipInstall "jinja2 2.8.1" "jinja2==2.8.1"
-        PipInstall "sphinx 1.5.6" "sphinx==1.5.6"
-        PipInstall "commonmark 0.7.3" "commonmark==0.7.3"
-        PipInstall "pillow 3.4.2" "pillow==3.4.2"
-        PipInstall "py2exe 0.6.9" "py2exe_py2==0.6.9"
-        PipInstall "pycrypto 2.6.1" "pycrypto==2.6.1"
-        PipInstall "comtypes 1.1.3" "https://github.com/enthought/comtypes/archive/1.1.3.zip"
-        PipInstall "ctypeslib 0.5.6" "svn+http://svn.python.org/projects/ctypes/trunk/ctypeslib/#ctypeslib=0.5.6"
-        PipInstall "paramiko 2.2.1" "paramiko==2.2.1"
-        PipInstall "pywin32 223" pywin32==223
       }
-      " "
-      "--- pywin32 post install"
-      $PywinPostInstall = $PythonScripts +"\pywin32_postinstall.py"
-      Start-Process python -Arg "$PywinPostInstall -install -silent -quiet" -Wait
-      "    Done."
-      #" "
-      #"--- Inno Setup 5.5.9"
-      #$InnoInstaller = $InstallersFolder + "innosetup-5.5.9-unicode.exe"
-      #$InnoURL = "http://files.jrsoftware.org/is/5/innosetup-5.5.9-unicode.exe"
-      #Start-FileDownload $InnoURL -Timeout 60000 -FileName $InnoInstaller | ForEach-Object { Write-Host "    " + $_ }
-      #"    Installing..."
-      #Start-Process $InnoInstaller -Arg "/SP /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /RESTARTAPPLICATIONS /NOICONS" -NoNewWindow -Wait
-      #"    Done."
-      " "
-      " "
       "=============== start the EventGhost build ==============="
       " "
       If ($Env:APPVEYOR_REPO_TAG.tolower() -eq "true" -and
@@ -130,10 +76,10 @@ install:
         git checkout -q master
         $release = $Env:APPVEYOR_REPO_TAG_NAME.split("_", 2)[1]
         $url = if($Env:SFTP_URL){' --docs --url "' + $env:SFTP_URL + '"'} else {''}
-        python "_build\Build.py" --build --package --release --version $release $url
+        python "_build\Build.py" --build --install --package --release --version $release $url
       } Else {
         # WIP
-        python "_build\Build.py" --build --package
+        python "_build\Build.py" --build --install --package
         .\EventGhost.exe -install
       }
       $Env:SetupExe = gci -recurse -filter "_build\output\*Setup.exe" -name

--- a/_build/Build.py
+++ b/_build/Build.py
@@ -100,7 +100,9 @@ class MyBuilder(builder.Builder):
         "wx.lib.pdfviewer",
         "wx.lib.pubsub"
         "wx.lib.iewin",
-        "wx.lib.iewin_old"
+        "wx.lib.iewin_old",
+        "jinja2.asyncsupport"
+        "jinja2.asyncfilters",
     ]
 
     def BuildInstaller(self):

--- a/_build/builder/BuildDocs.py
+++ b/_build/builder/BuildDocs.py
@@ -20,15 +20,11 @@ import codecs
 import os
 import re
 import shutil
-import sphinx
 from os.path import join
 
 # Local imports
 import builder
 from builder.Utils import EncodePath, GetHtmlHelpCompilerPath, StartProcess
-
-import eg
-from eg.Utils import GetFirstParagraph
 
 GUI_CLASSES = [
     "SpinIntCtrl",
@@ -98,6 +94,8 @@ class BuildHtmlDocs(builder.Task):
 
 
 def call_sphinx(builder, build_setup, dest_dir):
+    import sphinx
+
     WritePluginList(join(build_setup.docsDir, "pluginlist.rst"))
     Prepare(build_setup.docsDir)
     sphinx.build_main(
@@ -128,6 +126,8 @@ def call_sphinx(builder, build_setup, dest_dir):
 
 
 def BuildClsDocs(clsNames, doc_src_dir):
+    import eg
+
     res = []
     for clsName in clsNames:
         if clsName.startswith("-"):
@@ -181,6 +181,9 @@ def Prepare(doc_src_dir):
 
 
 def WritePluginList(filepath):
+    import eg
+    from eg.Utils import GetFirstParagraph
+
     kindList = [
         ("core", "Essential (always loaded)"),
         ("remote", "Remote Receiver"),

--- a/_build/builder/BuildInterpreters.py
+++ b/_build/builder/BuildInterpreters.py
@@ -30,9 +30,11 @@ from os.path import exists, join
 # Local imports
 import builder
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import py2exe  # NOQA
+
+# with warnings.catch_warnings():
+#     warnings.simplefilter("ignore")
+#     import py2exe  # NOQA
+
 
 PYVERSION = "%d%d" % sys.version_info[:2]
 PY_BASE_NAME = "py%s" % PYVERSION

--- a/_build/builder/BuildLibrary.py
+++ b/_build/builder/BuildLibrary.py
@@ -52,7 +52,7 @@ class BuildLibrary(builder.Task):
         from distutils.core import setup
         InstallPy2exePatch()
 
-        import py2exe
+        py2exe = __import__('py2exe')
         origIsSystemDLL = py2exe.build_exe.isSystemDLL
 
         def isSystemDLL(path):

--- a/_build/builder/BuildWebsite.py
+++ b/_build/builder/BuildWebsite.py
@@ -19,8 +19,7 @@
 import errno
 import os
 import time
-from docutils.core import publish_parts
-from jinja2 import Environment, FileSystemLoader
+
 from os.path import abspath, join
 
 # Local imports
@@ -36,6 +35,8 @@ class BuildWebsite(builder.Task):
             self.activated = bool(self.buildSetup.args.sync)
 
     def DoTask(self):
+        from jinja2 import Environment, FileSystemLoader
+
         buildSetup = self.buildSetup
         menuTabs = (HomePage, DocsPage, WikiPage, ForumPage, DownloadPage)
         env = Environment(
@@ -131,4 +132,5 @@ def GetSetupFiles(srcDir):
     return list(reversed(sorted(files, cmp=Cmp)))
 
 def rst2html(rst):
+    from docutils.core import publish_parts
     return publish_parts(rst, writer_name="html")["fragment"]

--- a/_build/builder/CheckDependencies.py
+++ b/_build/builder/CheckDependencies.py
@@ -291,32 +291,6 @@ class InnoSetupDependency(DependencyBase):
         )
 
 
-class SubVersionDependency(DependencyBase):
-    name = "Subversion"
-    version = ""
-    package = "svn"
-
-    def Check(self):
-        if self.buildSetup.download_dependencies:
-            proc = Popen('svn', stdout=PIPE, stderr=PIPE)
-            stderr, stdout = proc.communicate()
-            if 'svn help' not in stdout:
-                raise MissingDependency
-
-    def Download(self):
-        svn_path = os.path.join(temp_dir, 'svn')
-
-        install(
-            'https://sourceforge.net/projects/win32svn/files'
-            '/1.8.17/Setup-Subversion-1.8.17.msi/download',
-            'Setup-Subversion-1.8.17.msi',
-            'MsiExec /I %s /quiet /passive /qn '
-            '/norestart TARGETDIR=' + svn_path
-        )
-
-        os.environ['PATH'] += ';' + svn_path
-
-
 class VCRedistDependency(DllDependency):
     name = "Microsoft Visual C++ Redistributable"
     package = "vcredist2008"
@@ -515,7 +489,6 @@ class PIPDependency(ModuleDependency):
 DEPENDENCIES = [
     StacklessDependency(),
     PIPDependency(),
-    SubVersionDependency(),
     HtmlHelpWorkshopDependency(),
     InnoSetupDependency(),
     VCRedistDependency(),

--- a/_build/builder/Gui.py
+++ b/_build/builder/Gui.py
@@ -18,238 +18,469 @@
 
 import sys
 import threading
-import wx
+import time
+from Queue import Queue
 
 # Local imports
 import builder
 from builder.Utils import GetVersion, ParseVersion
 
 
-class MainDialog(wx.Dialog):
-    def __init__(self, buildSetup):
-        self.buildSetup = buildSetup
-        wx.Dialog.__init__(
-            self, None, title="Build %s Installer" % buildSetup.name
-        )
+_stdout = None
+_stderr = None
 
-        # create controls
-        self.ctrls = {}
-        ctrlsSizer = wx.BoxSizer(wx.VERTICAL)
-        for task in buildSetup.tasks:
-            if not task.visible:
-                continue
-            section = task.GetId()
-            ctrl = wx.CheckBox(self, -1, task.description)
-            if section.endswith(".BuildInstaller"):
-                checked = task.activated
-                ctrl.Bind(wx.EVT_CHECKBOX, self.OnInstallerCheck)
-            ctrl.SetValue(task.activated)
-            ctrlsSizer.Add(ctrl, 0, wx.ALL, 5)
-            self.ctrls[section] = ctrl
-            if not task.enabled:
-                ctrl.Enable(False)
+class CtrlWriter(threading.Thread):
 
-        if checked:
-            self.OnInstallerCheck(True)
+    def __init__(self, ctrl):
+        self._ctrl = ctrl
+        self._queue = Queue()
+        self._scroll_queue = []
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.scroll_position = 0
 
-        self.okButton = wx.Button(self, wx.ID_OK)
-        self.okButton.Bind(wx.EVT_BUTTON, self.OnOk)
-        self.okButton.SetDefault()
-        self.cancelButton = wx.Button(self, wx.ID_CANCEL)
-        self.cancelButton.Bind(wx.EVT_BUTTON, self.OnCancel)
+    def run(self):
+        import wx
 
-        # add controls to sizers
-        btnSizer = wx.StdDialogButtonSizer()
-        btnSizer.AddButton(self.okButton)
-        btnSizer.AddButton(self.cancelButton)
-        btnSizer.Realize()
+        global old_scroll_position
+        char_height = self._ctrl.GetCharHeight()
 
-        sizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        sizer2.Add(ctrlsSizer)
+        old_scroll_position = self.scroll_position
 
-        # create controls for github connection
-        ghSzr = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, u"GitHub"), wx.VERTICAL)
-        sb = ghSzr.GetStaticBox()
-
-        lblRepo = wx.StaticText(sb, wx.ID_ANY, u"Repository:")
-        self.chcRepo = wx.Choice(sb, wx.ID_ANY)
-        repos = buildSetup.gitConfig["all_repos"].keys()
-        self.chcRepo.SetItems(repos)
-        self.chcRepo.SetStringSelection(buildSetup.gitConfig["repo_full"])
-        self.chcRepo.Bind(wx.EVT_CHOICE, self.OnRepoSelection)
-
-        lblBranch = wx.StaticText(sb, wx.ID_ANY, u"Branch:")
-        self.chcBranch = wx.Choice(sb, wx.ID_ANY)
-        self.chcBranch.SetItems(
-            buildSetup.gitConfig["all_repos"]
-            [buildSetup.gitConfig["repo_full"]]["all_branches"]
-        )
-        self.chcBranch.SetStringSelection(
-            buildSetup.gitConfig["all_repos"]
-            [buildSetup.gitConfig["repo_full"]]["def_branch"]
-        )
-
-        grdSzr = wx.FlexGridSizer(0, 2, 0, 0)
-        grdSzr.SetFlexibleDirection(wx.BOTH)
-        grdSzr.SetNonFlexibleGrowMode(wx.FLEX_GROWMODE_SPECIFIED)
-        grdSzr.Add(lblRepo, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 5)
-        grdSzr.Add(self.chcRepo, 0, wx.ALL | wx.EXPAND, 5)
-        grdSzr.Add(lblBranch, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 5)
-        grdSzr.Add(self.chcBranch, 0, wx.ALL | wx.EXPAND, 5)
-        grdSzr.AddGrowableCol(1)
-        ghSzr.Add(grdSzr, 1, wx.EXPAND)
-
-        if not self.buildSetup.gitConfig["token"]:
-            sb.Disable()
-
-        egSzr = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, "EventGhost"), wx.HORIZONTAL)
-
-        sb = egSzr.GetStaticBox()
-        lblVersion = wx.StaticText(sb, wx.ID_ANY, "Version to build:")
-        self.versionStr = wx.TextCtrl(sb, wx.ID_ANY)
-        self.UpdateVersion()
-
-        refreshVersion = wx.BitmapButton(sb, wx.ID_ANY, wx.ArtProvider.
-                                         GetBitmap(wx.ART_GO_DOWN))
-        refreshVersion.SetToolTip(wx.ToolTip(
-            'Get Version from GitHub. Before using,\n'
-            'please fill the github section above.'))
-        refreshVersion.Bind(wx.EVT_BUTTON, self.OnRefreshVersion)
-
-        if not self.buildSetup.gitConfig["token"]:
-            sb.Disable()
-
-        egSzr.Add(lblVersion, 0, wx.ALIGN_CENTER_VERTICAL |
-                  wx.LEFT | wx.RIGHT, 5)
-        egSzr.Add(self.versionStr, 1, wx.ALIGN_CENTER_VERTICAL |
-                  wx.LEFT | wx.RIGHT, 5)
-        egSzr.Add(refreshVersion, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-
-        if not self.buildSetup.gitConfig["token"]:
-            refreshVersion.Disable()
-
-        # widgets for website updating
-        web_szr = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, u"Website (docs)"), wx.VERTICAL)
-        sb = web_szr.GetStaticBox()
-        url_txt = 'URL (sftp://<user>:<pw>@<domain.net>:' \
-                  '<port>/<root/of/website>/)'
-        lbl_url = wx.StaticText(
-            parent=sb,
-            label=url_txt
-        )
-        lbl_url.SetToolTipString(url_txt)
-        self.url = wx.TextCtrl(sb, value=self.buildSetup.args.websiteUrl)
-        self.url.SetToolTipString(url_txt)
-        web_szr.Add(lbl_url)
-        web_szr.Add(self.url, 0, wx.EXPAND)
-
-        # combine all controls to a main sizer
-        mainSizer = wx.BoxSizer(wx.VERTICAL)
-        mainSizer.Add(ghSzr, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL | wx.EXPAND, 5)
-        mainSizer.Add(egSzr, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL | wx.EXPAND, 5)
-        mainSizer.Add(web_szr, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL | wx.EXPAND, 5)
-        mainSizer.Add(sizer2, 1, wx.ALL | wx.EXPAND, 10)
-        mainSizer.Add(btnSizer, 0, wx.ALL | wx.ALIGN_RIGHT | wx.EXPAND, 10)
-        self.SetSizerAndFit(mainSizer)
-        self.Center()
-        self.Bind(wx.EVT_CLOSE, self.OnClose)
-
-    def DoMain(self):
-        builder.Tasks.Main(self.buildSetup)
-        wx.CallAfter(self.OnExit)
-
-    def OnCancel(self, event):
-        event.Skip()
-        self.Destroy()
-        wx.GetApp().ExitMainLoop()
-
-    def OnClose(self, event):
-        event.Skip()
-        self.Destroy()
-        wx.GetApp().ExitMainLoop()
-
-    def OnExit(self):
-        self.Destroy()
-        sys.exit(0)
-
-    def OnInstallerCheck(self, event):
-        # We don't want releases going out without a current changelog (which
-        # is also included in the documentation), so let's force both to be
-        # built when building the installer.
-        for ctrl in (
-            self.ctrls["builder.BuildChangelog.BuildChangelog"],
-            self.ctrls["builder.BuildDocs.BuildChmDocs"],
-        ):
-            if event is True or event.Checked():
-                ctrl.Enable(False)
-                ctrl.SetValue(True)
-            else:
-                ctrl.Enable(True)
-
-    def OnOk(self, dummyEvent):
-        repository = self.chcRepo.GetStringSelection()
         try:
-            user, repo = repository.split('/')
-        except ValueError:
-            dlg = wx.MessageDialog(
-                self,
-                caption="Information",
-                style=wx.OK,
-                message="Repositoryname not valid. Must be:\n"
-                "<user or organization>/<repository>."
-            )
-            dlg.ShowModal()
-            return
+            while True:
+                def do():
+                    global old_scroll_position
 
-        for child in self.GetChildren():
-            child.Enable(False)
-        #self.SetWindowStyleFlag(wx.CAPTION|wx.RESIZE_BORDER)
-        for task in self.buildSetup.tasks:
-            if not task.visible:
-                continue
-            section = task.GetId()
-            if section in self.ctrls:
-                ctrl = self.ctrls[section]
-                task.activated = ctrl.GetValue()
-        (
-            self.buildSetup.appVersion,
-            self.buildSetup.appVersionInfo
-        ) = (
-            ParseVersion(self.versionStr.GetValue())
-        )
-        self.buildSetup.gitConfig.update({
-            "user": user,
-            "repo": repo,
-            "branch": self.chcBranch.GetStringSelection(),
-        })
-        self.buildSetup.args.websiteUrl = self.url.GetValue()
+                    # self._ctrl.Freeze()
 
-        self.buildSetup.config.SaveSettings()
-        thread = threading.Thread(target=self.DoMain)
-        thread.start()
+                    shown_lines = int(
+                        self._ctrl.GetSizeTuple()[1] / char_height
+                    )
+                    if new_scroll_position is None:
+                        scroll_pos = old_scroll_position
+                    else:
+                        scroll_pos = new_scroll_position
 
-    def OnRefreshVersion(self, event):
-        GetVersion(self.buildSetup)
-        self.UpdateVersion()
+                    scroll_line = self._ctrl.PositionToXY(scroll_pos)[1]
 
-    def OnRepoSelection(self, event):
-        key = self.chcRepo.GetStringSelection()
-        self.chcBranch.SetItems(
-            self.buildSetup.gitConfig["all_repos"][key]["all_branches"]
-        )
-        self.chcBranch.SetStringSelection(
-            self.buildSetup.gitConfig["all_repos"][key]["def_branch"]
-        )
+                    stop_pos = self._ctrl.GetLastPosition()
+                    page_stop = self._ctrl.PositionToXY(stop_pos)[1]
+                    page_start = page_stop - shown_lines
 
-    def UpdateVersion(self):
-        if not self.buildSetup.appVersion.startswith("WIP-"):
-            self.versionStr.SetValue(self.buildSetup.appVersion)
+                    if page_start < 0:
+                        page_start -= page_start
+                        page_start, page_stop = page_stop, page_start
+
+                    # _stdout.write(
+                    #     str(page_start) + ' : ' + str(page_stop) + ' : ' + str(
+                    #         scroll_line))
+
+                    self._ctrl.SetInsertionPointEnd()
+                    if text is not None:
+                        self._ctrl.WriteText(text)
+
+                    if color is not None:
+                        self._ctrl.SetStyle(
+                            stop_pos,
+                            stop_pos + len(text),
+                            wx.TextAttr(wx.Colour(*color))
+                        )
+
+                    if page_start <= 0 or page_start <= scroll_line <= page_stop:
+                        self._ctrl.SetInsertionPoint(
+                            self._ctrl.GetLastPosition()
+                        )
+                        old_scroll_position = self.scroll_position = (
+                            self._ctrl.GetLastPosition()
+                        )
+                    else:
+                        old_scroll_position = scroll_pos
+                        self._ctrl.SetInsertionPoint(scroll_pos)
+                    # self._ctrl.Thaw()
+
+                text = None
+                color = None
+
+                while self._scroll_queue:
+                    new_scroll_position = self._scroll_queue.pop()
+                    do()
+
+                new_scroll_position = None
+
+                if not self._queue.empty():
+                    text, color = self._queue.get()
+                    self._queue.task_done()
+                    do()
+        except:
+            pass
+
+    def put(self, text, color=None):
+        self._queue.put((text, color))
+
+    def put_scroll(self, scroll):
+        self._scroll_queue += [scroll]
+
+
+class GUIStdOut:
+
+    def __init__(self, ctrl):
+        self._ctrl = ctrl
+
+    def write(self, data):
+        self._ctrl.put(data)
+
+    def __getattr__(self, item):
+        return getattr(_stdout, item)
+
+
+class GUIStdErr:
+
+    def __init__(self, ctrl):
+        self._ctrl = ctrl
+
+    def write(self, data):
+        self._ctrl.put(data, (255, 0, 0))
+
+    def __getattr__(self, item):
+        return getattr(_stderr, item)
 
 
 def Main(buildSetup):
+    from CheckDependencies import DEPENDENCIES, PIPDependency
+
+    pip_dep = PIPDependency()
+    try:
+        pip_dep.Check()
+    except:
+        if buildSetup.download_dependencies:
+            pip_dep.Download()
+            pip_dep.Check()
+        else:
+            raise
+    try:
+        DEPENDENCIES[-1].Check()
+    except:
+        if buildSetup.download_dependencies:
+            DEPENDENCIES[-1].Download()
+            DEPENDENCIES[-1].Check()
+        else:
+            raise
+
+    import wx
+
+    class MainDialog(wx.Frame):
+        def __init__(self, buildSetup):
+            self.buildSetup = buildSetup
+            wx.Frame.__init__(
+                self,
+                None,
+                title="Build %s Installer" % buildSetup.name,
+            )
+
+            # create controls
+            self.ctrls = {}
+            ctrlsSizer = wx.BoxSizer(wx.HORIZONTAL)
+            leftSizer = wx.BoxSizer(wx.VERTICAL)
+            rightSizer = wx.BoxSizer(wx.VERTICAL)
+            self.download_dependencies_ctrl = wx.CheckBox(
+                self,
+                -1,
+                'Download Dependencies'
+            )
+            self.download_dependencies_ctrl.SetValue(buildSetup.download_dependencies)
+            leftSizer.Add(self.download_dependencies_ctrl, 0, wx.ALL, 5)
+            self.download_dependencies_ctrl.Bind(
+                wx.EVT_CHECKBOX,
+                self.OnDownloadDependencies
+            )
+
+            for i, task in enumerate(buildSetup.tasks):
+                if not task.visible:
+                    continue
+                section = task.GetId()
+                ctrl = wx.CheckBox(self, -1, task.description)
+                if section.endswith(".BuildInstaller"):
+                    checked = task.activated
+                    ctrl.Bind(wx.EVT_CHECKBOX, self.OnInstallerCheck)
+                ctrl.SetValue(task.activated)
+                if i < 7:
+                    leftSizer.Add(ctrl, 0, wx.ALL, 5)
+                else:
+                    rightSizer.Add(ctrl, 0, wx.ALL, 5)
+                self.ctrls[section] = ctrl
+                if not task.enabled:
+                    ctrl.Enable(False)
+
+            if checked:
+                self.OnInstallerCheck(True)
+
+            self.okButton = wx.Button(self, wx.ID_OK)
+            self.okButton.Bind(wx.EVT_BUTTON, self.OnOk)
+            self.okButton.SetDefault()
+            self.cancelButton = wx.Button(self, wx.ID_CANCEL)
+            self.cancelButton.Bind(wx.EVT_BUTTON, self.OnCancel)
+
+            # add controls to sizers
+            btnSizer = wx.StdDialogButtonSizer()
+            btnSizer.AddButton(self.okButton)
+            btnSizer.AddButton(self.cancelButton)
+            btnSizer.Realize()
+
+            ctrlsSizer.Add(leftSizer)
+            ctrlsSizer.Add(rightSizer)
+
+            sizer2 = wx.BoxSizer(wx.HORIZONTAL)
+            sizer2.Add(ctrlsSizer)
+
+            # create controls for github connection
+            ghSzr = wx.StaticBoxSizer(
+                wx.StaticBox(self, wx.ID_ANY, u"GitHub"), wx.VERTICAL)
+            sb = ghSzr.GetStaticBox()
+
+            lblRepo = wx.StaticText(sb, wx.ID_ANY, u"Repository:")
+            self.chcRepo = wx.Choice(sb, wx.ID_ANY)
+            repos = buildSetup.gitConfig["all_repos"].keys()
+            self.chcRepo.SetItems(repos)
+            self.chcRepo.SetStringSelection(buildSetup.gitConfig["repo_full"])
+            self.chcRepo.Bind(wx.EVT_CHOICE, self.OnRepoSelection)
+
+            lblBranch = wx.StaticText(sb, wx.ID_ANY, u"Branch:")
+            self.chcBranch = wx.Choice(sb, wx.ID_ANY)
+            self.chcBranch.SetItems(
+                buildSetup.gitConfig["all_repos"]
+                [buildSetup.gitConfig["repo_full"]]["all_branches"]
+            )
+            self.chcBranch.SetStringSelection(
+                buildSetup.gitConfig["all_repos"]
+                [buildSetup.gitConfig["repo_full"]]["def_branch"]
+            )
+
+            grdSzr = wx.FlexGridSizer(0, 2, 0, 0)
+            grdSzr.SetFlexibleDirection(wx.BOTH)
+            grdSzr.SetNonFlexibleGrowMode(wx.FLEX_GROWMODE_SPECIFIED)
+            grdSzr.Add(lblRepo, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 5)
+            grdSzr.Add(self.chcRepo, 0, wx.ALL | wx.EXPAND, 5)
+            grdSzr.Add(lblBranch, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 5)
+            grdSzr.Add(self.chcBranch, 0, wx.ALL | wx.EXPAND, 5)
+            grdSzr.AddGrowableCol(1)
+            ghSzr.Add(grdSzr, 1, wx.EXPAND)
+
+            if not self.buildSetup.gitConfig["token"]:
+                sb.Disable()
+
+            egSzr = wx.StaticBoxSizer(
+                wx.StaticBox(self, wx.ID_ANY, "EventGhost"), wx.HORIZONTAL)
+
+            sb = egSzr.GetStaticBox()
+            lblVersion = wx.StaticText(sb, wx.ID_ANY, "Version to build:")
+            self.versionStr = wx.TextCtrl(sb, wx.ID_ANY)
+            self.UpdateVersion()
+
+            refreshVersion = wx.BitmapButton(sb, wx.ID_ANY, wx.ArtProvider.
+                                             GetBitmap(wx.ART_GO_DOWN))
+            refreshVersion.SetToolTip(wx.ToolTip(
+                'Get Version from GitHub. Before using,\n'
+                'please fill the github section above.'))
+            refreshVersion.Bind(wx.EVT_BUTTON, self.OnRefreshVersion)
+
+            if not self.buildSetup.gitConfig["token"]:
+                sb.Disable()
+
+            egSzr.Add(lblVersion, 0, wx.ALIGN_CENTER_VERTICAL |
+                      wx.LEFT | wx.RIGHT, 5)
+            egSzr.Add(self.versionStr, 1, wx.ALIGN_CENTER_VERTICAL |
+                      wx.LEFT | wx.RIGHT, 5)
+            egSzr.Add(refreshVersion, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+
+            if not self.buildSetup.gitConfig["token"]:
+                refreshVersion.Disable()
+
+            # widgets for website updating
+            web_szr = wx.StaticBoxSizer(
+                wx.StaticBox(self, wx.ID_ANY, u"Website (docs)"), wx.VERTICAL)
+            sb = web_szr.GetStaticBox()
+            url_txt = 'URL (sftp://<user>:<pw>@<domain.net>:' \
+                      '<port>/<root/of/website>/)'
+            lbl_url = wx.StaticText(
+                parent=sb,
+                label=url_txt
+            )
+
+            lbl_url.SetToolTip(wx.ToolTip(url_txt))
+            self.url = wx.TextCtrl(sb, value=self.buildSetup.args.websiteUrl)
+            self.url.SetToolTip(wx.ToolTip(url_txt))
+            web_szr.Add(lbl_url)
+            web_szr.Add(self.url, 0, wx.EXPAND)
+
+            loggingCtrl = self.loggingCtrl = wx.TextCtrl(
+                self,
+                -1,
+                '',
+                style=wx.TE_READONLY | wx.TE_MULTILINE | wx.TE_RICH2,
+                size=(-1, 200)
+            )
+            loggingCtrl.HideNativeCaret()
+
+            global _stdout
+            global _stderr
+
+            _stdout = sys.stdout
+            _stderr = sys.stderr
+
+            ctrl_writer = CtrlWriter(loggingCtrl)
+
+            sys.stdout = GUIStdOut(ctrl_writer)
+            sys.stderr = GUIStdErr(ctrl_writer)
+
+            def on_scroll(evt):
+                if evt.GetOrientation() == wx.VERTICAL:
+                    ctrl_writer.put_scroll(evt.GetPosition())
+                evt.Skip()
+
+            loggingCtrl.Bind(wx.EVT_SCROLLWIN, on_scroll)
+            loggingCtrl.Bind(wx.EVT_SCROLL, on_scroll)
+
+            def on_bottom(evt):
+                if evt.GetOrientation() == wx.VERTICAL:
+                    ctrl_writer.put_scroll(100000000)
+                evt.Skip()
+
+            loggingCtrl.Bind(wx.EVT_SCROLL_BOTTOM, on_bottom)
+            loggingCtrl.Bind(wx.EVT_SCROLLWIN_BOTTOM, on_bottom)
+
+            ctrl_writer.start()
+
+            # combine all controls to a main sizer
+            mainSizer = wx.BoxSizer(wx.VERTICAL)
+            centerSizer = wx.BoxSizer(wx.HORIZONTAL)
+            mainLeftSizer = wx.BoxSizer(wx.VERTICAL)
+            mainRightSizer = wx.BoxSizer(wx.VERTICAL)
+
+            mainLeftSizer.Add(ghSzr, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL | wx.EXPAND, 5)
+            mainLeftSizer.Add(egSzr, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL | wx.EXPAND, 5)
+            mainLeftSizer.Add(web_szr, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL | wx.EXPAND, 5)
+            mainLeftSizer.Add(sizer2, 0, wx.ALL | wx.EXPAND, 10)
+            mainRightSizer.Add(loggingCtrl, 1, wx.ALL | wx.EXPAND, 5)
+
+            centerSizer.Add(mainLeftSizer)
+            centerSizer.Add(mainRightSizer, 1, wx.EXPAND)
+            mainSizer.Add(centerSizer, 0,  wx.EXPAND)
+            mainSizer.Add(btnSizer, 0, wx.ALL | wx.ALIGN_RIGHT | wx.EXPAND, 10)
+            self.SetSizerAndFit(mainSizer)
+            self.SetSize((768, -1))
+            self.Center()
+            self.Bind(wx.EVT_CLOSE, self.OnClose)
+
+        def DoMain(self):
+            builder.Tasks.Main(self.buildSetup)
+            sys.stderr.write('\nDone!\n')
+
+        def OnCancel(self, event):
+            sys.stdout = _stdout
+            sys.stderr = _stderr
+            event.Skip()
+            self.Destroy()
+            wx.GetApp().ExitMainLoop()
+
+        def OnClose(self, event):
+            sys.stdout = _stdout
+            sys.stderr = _stderr
+            event.Skip()
+            self.Destroy()
+            # wx.GetApp().ExitMainLoop()
+            sys.exit(0)
+
+        def OnExit(self):
+            sys.stdout = _stdout
+            sys.stderr = _stderr
+            self.Destroy()
+            sys.exit(0)
+
+        def OnDownloadDependencies(self, event):
+            self.buildSetup.download_dependencies = (
+                self.download_dependencies_ctrl.GetValue()
+            )
+
+        def OnInstallerCheck(self, event):
+            # We don't want releases going out without a current changelog (which
+            # is also included in the documentation), so let's force both to be
+            # built when building the installer.
+            for ctrl in (
+                self.ctrls["builder.BuildChangelog.BuildChangelog"],
+                self.ctrls["builder.BuildDocs.BuildChmDocs"],
+            ):
+                if event is True or event.Checked():
+                    ctrl.Enable(False)
+                    ctrl.SetValue(True)
+                else:
+                    ctrl.Enable(True)
+
+        def OnOk(self, dummyEvent):
+            repository = self.chcRepo.GetStringSelection()
+            try:
+                user, repo = repository.split('/')
+            except ValueError:
+                dlg = wx.MessageDialog(
+                    self,
+                    caption="Information",
+                    style=wx.OK,
+                    message="Repositoryname not valid. Must be:\n"
+                    "<user or organization>/<repository>."
+                )
+                dlg.ShowModal()
+                return
+
+            for child in self.GetChildren():
+                child.Enable(False)
+
+            self.loggingCtrl.Enable(True)
+            #self.SetWindowStyleFlag(wx.CAPTION|wx.RESIZE_BORDER)
+            for task in self.buildSetup.tasks:
+                if not task.visible:
+                    continue
+                section = task.GetId()
+                if section in self.ctrls:
+                    ctrl = self.ctrls[section]
+                    task.activated = ctrl.GetValue()
+            (
+                self.buildSetup.appVersion,
+                self.buildSetup.appVersionInfo
+            ) = (
+                ParseVersion(self.versionStr.GetValue())
+            )
+            self.buildSetup.gitConfig.update({
+                "user": user,
+                "repo": repo,
+                "branch": self.chcBranch.GetStringSelection(),
+            })
+            self.buildSetup.args.websiteUrl = self.url.GetValue()
+
+            self.buildSetup.config.SaveSettings()
+            thread = threading.Thread(target=self.DoMain)
+            thread.start()
+
+        def OnRefreshVersion(self, event):
+            GetVersion(self.buildSetup)
+            self.UpdateVersion()
+
+        def OnRepoSelection(self, event):
+            key = self.chcRepo.GetStringSelection()
+            self.chcBranch.SetItems(
+                self.buildSetup.gitConfig["all_repos"][key]["all_branches"]
+            )
+            self.chcBranch.SetStringSelection(
+                self.buildSetup.gitConfig["all_repos"][key]["def_branch"]
+            )
+
+        def UpdateVersion(self):
+            if not self.buildSetup.appVersion.startswith("WIP-"):
+                self.versionStr.SetValue(self.buildSetup.appVersion)
+
+    for task in buildSetup.tasks:
+        task.Setup()
+    (buildSetup.appVersion, buildSetup.appVersionInfo) = GetVersion(buildSetup)
+
     app = wx.App(0)
     app.SetExitOnFrameDelete(True)
     mainDialog = MainDialog(buildSetup)

--- a/_build/builder/ReleaseToGitHub.py
+++ b/_build/builder/ReleaseToGitHub.py
@@ -18,8 +18,7 @@
 
 import base64
 import sys
-import wx
-from agithub.GitHub import GitHub
+
 from os import environ
 from os.path import join
 
@@ -49,6 +48,9 @@ class ReleaseToGitHub(builder.Task):
             )
 
     def DoTask(self):
+        import wx
+        from agithub.GitHub import GitHub
+
         buildSetup = self.buildSetup
         appVer = "v" + buildSetup.appVersion
         gitConfig = buildSetup.gitConfig

--- a/_build/builder/Tasks.py
+++ b/_build/builder/Tasks.py
@@ -144,10 +144,17 @@ TASKS = [
     SynchronizeWebsite,
 ]
 
+
 def Main(buildSetup):
     """
     Main task of the script.
     """
+
+    from CheckDependencies import CheckDependencies
+
+    if not CheckDependencies(buildSetup):
+        sys.exit(1)
+
     for task in buildSetup.tasks:
         if task.activated:
             logger.log(22, "--- {0}".format(task.description))


### PR DESCRIPTION
I have updated the builder and added these new features

I added the ability to download every dependency except for Stackless python. This can be started by using the -install cli switch or in the GUI. In the event the user running the GUI does not have wxPython installed if you use the -- install switch it will install wxPython then launch the GUI and still give you the option of installing the rest.

I updated all of the versions of the dependencies, including Sphinx. There are 2 files that are packaged with the newest version of Jinja2 (required by Sphinx), these 2 files are written in asyncio syntax for python 3. Even tho they never get imported they still get byte compiled by distutils. And this is where it goes south. It took me a while to locate the issue. I set the builder to modify the Jinja2 installation. I have it try to load each file in the Jinja2 package and if it fails because of a SyntaxError that file will be deleted. Now it only does this if the builder downloaded and installed Jinja2 and not if it was already existing. We don't have the right to modify any data that the builder did not create.

ctypeslib - There is a better way! Someone has continued the work on ctypeslib but has named it ctypeslib2. It functions the exact same and carry's the same module name so we are not able to update this as well. It is hosted on PyPi also.

I believe I have all deps at their newest version now except for stackless and wxPython. 

I reformatted the GUI to allow for room for a couple new controls. I added the download dependencies checkbox, I also added a logging output window. It only displays the verbose logging data. This logging information does not get sent to the console window. The console window output is the same as before. It makes the text red if there are any errors, and allows for scrolling while it is running.. errr kind of?! it can be a little bit of a pain to do but it does work. 

I updated appveyor script to use the new --install cli switch. One less thing we now have to maintain.

Oh yeah. if the --install cli switch is used and the package already exists but it is a lower version. The builder will go ahead and update it.

There was a curious issue I always had with the builder when using the GUI. it would always hang and not exit properly. I would have to go and kill the process. I do not know what i did but i no longer have that issue. The build dialog remains open after a build or an attempt to build so the user has the ability to view the log. 

