### PR TITLE
[EventGhost] - BugFix - NamedPipe.py, Rewrite in pure python

### DIFF
--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -158,7 +158,7 @@ if args.isMain:
         args.isMain # and
         # not args.pluginFile
     ):
-        if NamedPipe.is_eg_running:
+        if NamedPipe.is_eg_running():
             if args.restart:
                 restart()
             else:

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -62,9 +62,6 @@ eg.CORE_PLUGIN_GUIDS = (
 
 eg.namedPipe = NamedPipe.Server()
 
-if eg.Cli.args.isMain:
-    eg.namedPipe.start()
-
 eg.ID_TEST = wx.NewId()
 eg.mainDir = eg.Cli.mainDir
 

--- a/eg/Core.py
+++ b/eg/Core.py
@@ -359,6 +359,7 @@ if eg.startupArguments.isMain and not eg.startupArguments.translate:
     eg.text = eg.Text(eg.config.language)
 else:
     eg.text = eg.Text('en_EN')
+
 eg.actionThread = eg.ActionThread()
 eg.eventThread = eg.EventThread()
 eg.pluginManager = eg.PluginManager()
@@ -385,3 +386,4 @@ eg.wit = None
 
 eg.Init = Init
 eg.Init.Init()
+

--- a/eg/NamedPipe.py
+++ b/eg/NamedPipe.py
@@ -100,13 +100,6 @@ from ctypes.wintypes import (
     LPCVOID
 )
 
-
-def write_error(*msg):
-    msg = ' '.join(repr(item) for item in msg)
-    sys.stderr.write(msg + '\n')
-
-
-write_error('loading eg.NamedPipe module')
 __version__ = '0.1.0b'
 
 # various c types that get used when passing data to the Windows functions
@@ -226,8 +219,6 @@ kernel32 = ctypes.windll.kernel32
 # Windows security API
 advapi32 = ctypes.windll.advapi32
 
-
-write_error('creating structures')
 
 # c type structure that handles the overlapped io portion of the pipe
 # not used currently here for completeness
@@ -445,8 +436,6 @@ def format_error(err):
 # Checks for the instance of a running pipe. I created this new function so
 # eg.NamedPipe can be used in plugins if needed.
 def is_pipe_running(pipe_name):
-    write_error('checking for running pipe')
-
     lpName = ctypes.create_unicode_buffer(_create_pipe_name(pipe_name))
     dwOpenMode = DWORD(PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE)
     dwPipeMode = DWORD(PIPE_TYPE_MESSAGE | PIPE_WAIT | PIPE_READMODE_MESSAGE)
@@ -476,13 +465,11 @@ def is_pipe_running(pipe_name):
         return False
 
     else:
-        write_error(err)
         raise PipeConnectionError(err)
 
 
 # This is specific to checking is the eventghost named pipe is running
 def is_eg_running():
-    write_error('is pipe running')
     return is_pipe_running('eventghost')
 
 
@@ -881,7 +868,6 @@ class Server:
     """
 
     def __init__(self, pipe_name='eventghost'):
-        write_error('creating server')
         self._pipe_name = pipe_name
         self._thread = None
         self.running_pipes = []
@@ -889,7 +875,6 @@ class Server:
         self._available_event = threading.Event()
 
     def start(self):
-        write_error('starting server')
         if self._thread is None:
             self._thread = threading.Thread(
                 name='{0}.Pipe.Thread'.format(self._pipe_name),
@@ -950,7 +935,6 @@ def send_message(msg, pipe_name='eventghost'):
         )
 
         err = GetLastError()
-        write_error('connect', hNamedPipe, err)
 
         lpNamedPipeName = lpFileName
         nTimeOut = DWORD(2000)
@@ -996,8 +980,6 @@ def send_message(msg, pipe_name='eventghost'):
         )
 
         err = GetLastError()
-
-        write_error('write', msg, result, err)
 
         if err == ERROR_MORE_DATA:
             msg = msg[lpNumberOfBytesWritten.value:]

--- a/eg/__init__.py
+++ b/eg/__init__.py
@@ -83,6 +83,7 @@ class DynamicModule(object):
             eg.PluginInstall.Import(Cli.args.pluginFile)
             return
         else:
+            eg.namedPipe.start()
             eg.Init.InitGui()
         if eg.debugLevel:
             try:


### PR DESCRIPTION
Removes use of pywin32 for handling the named pipe.

Only uses python std lib

Changes handling of commands so only commands directed to eg.document or eg.mainFrame will be run in the main thread.

Changes the closing of the Pipe so the client has to initiate the close by sending CLOSE. this allows the pipe connection to remain open for further commands to be sent over the pipe without the need to create a new connection.

Changes the pipe so a pipe name can be supplied. This is so that the named pipe code is not dedicated to only the use of EG. it can now be used in plugins or a script if needed.

Changes the pipe instance checker. I have created a separate function is_pipe_running that allows the user to supply a pipe name to check for the instance of a named pipe.

Changes the exception creation in the command processor to no longer throw exceptions. Instead if an error occurs the returned value will be one of the following.

CommandFormatError
ParameterFormatError
CommandMalformedError
CommandNotFoundError

There is also the following 2 errors that can be returned. These are only returned in the event of the command that was executed not returning within 5 seconds. because we run the command in 2 different threads the main thread or some other thread the returned error values will reflect that.
MainThreadHung
UnableToProcessCommand

