### PR TITLE
BuildLibrary.py: fix SyntaxError in py2exe for Jinja2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,11 +90,7 @@ install:
         pip install -q -U "setuptools==34.3.0"
         "    Done."
         PipInstall "wheel 0.29.0" "wheel==0.29.0"
-        # sphinx >= 1.4.9 installs jinja2 >= 2.3 as dependency,
-        # jinja2 >= 2.9 has an async module which py2exe has
-        # problems with (build of eg will fail)
-        PipInstall "jinja2 2.8.1" "jinja2==2.8.1"
-        PipInstall "sphinx 1.5.6" "sphinx==1.5.6"
+        PipInstall "sphinx 1.5.6" "sphinx=1.7.5"
         PipInstall "commonmark 0.7.3" "commonmark==0.7.3"
         PipInstall "pillow 3.4.2" "pillow==3.4.2"
         PipInstall "py2exe 0.6.9" "py2exe_py2==0.6.9"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,7 @@ install:
         pip install -q -U "setuptools==34.3.0"
         "    Done."
         PipInstall "wheel 0.29.0" "wheel==0.29.0"
-        PipInstall "sphinx 1.5.6" "sphinx==1.7.5"
+        PipInstall "sphinx 1.7.5" "sphinx==1.7.5"
         PipInstall "commonmark 0.7.3" "commonmark==0.7.3"
         PipInstall "pillow 3.4.2" "pillow==3.4.2"
         PipInstall "py2exe 0.6.9" "py2exe_py2==0.6.9"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,7 @@ install:
         pip install -q -U "setuptools==34.3.0"
         "    Done."
         PipInstall "wheel 0.29.0" "wheel==0.29.0"
-        PipInstall "sphinx 1.5.6" "sphinx=1.7.5"
+        PipInstall "sphinx 1.5.6" "sphinx==1.7.5"
         PipInstall "commonmark 0.7.3" "commonmark==0.7.3"
         PipInstall "pillow 3.4.2" "pillow==3.4.2"
         PipInstall "py2exe 0.6.9" "py2exe_py2==0.6.9"

--- a/_build/builder/BuildLibrary.py
+++ b/_build/builder/BuildLibrary.py
@@ -32,18 +32,15 @@ orig_compile = __builtin__.compile
 
 def my_compile(source, filename, *args):
     try:
-        result = orig_compile(source, filename, *args)
+        return orig_compile(source, filename, *args)
     except SyntaxError:
-        if 'import asyncio' in source or 'from asyncio' in source:
-            ver = sys.version_info
-            if ver[0] < 3 or ver[1] < 5:
-                return orig_compile('', filename, *args)
-            else:
-                raise
-        else:
-            raise
+        ver = sys.version_info
 
-    return result
+        if ver[0] > 2 and ver[1] > 4:
+            raise
+        if 'import asyncio' in source or 'from asyncio' in source:
+            return orig_compile('', filename, *args)
+        raise
 
 
 __builtin__.compile = my_compile

--- a/_build/builder/BuildLibrary.py
+++ b/_build/builder/BuildLibrary.py
@@ -27,23 +27,24 @@ import builder
 from builder.Utils import EncodePath
 
 
-orig_compile = __builtin__.compile
+_compile = __builtin__.compile
 
 
-def my_compile(source, filename, *args):
+# noinspection PyShadowingBuiltins
+def compile(source, filename, *args):
     try:
-        return orig_compile(source, filename, *args)
+        return _compile(source, filename, *args)
     except SyntaxError:
         ver = sys.version_info
 
         if ver[0] > 2 and ver[1] > 4:
             raise
         if 'import asyncio' in source or 'from asyncio' in source:
-            return orig_compile('', filename, *args)
+            return _compile('', filename, *args)
         raise
 
 
-__builtin__.compile = my_compile
+__builtin__.compile = compile
 
 DLL_EXCLUDES = [
     "DINPUT8.dll",

--- a/_build/builder/BuildLibrary.py
+++ b/_build/builder/BuildLibrary.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License along
 # with EventGhost. If not, see <http://www.gnu.org/licenses/>.
 
+import __builtin__
 import os
 import sys
 from glob import glob
@@ -24,6 +25,28 @@ from os.path import basename, exists, join
 # Local imports
 import builder
 from builder.Utils import EncodePath
+
+
+orig_compile = __builtin__.compile
+
+
+def my_compile(source, filename, *args):
+    try:
+        result = orig_compile(source, filename, *args)
+    except SyntaxError:
+        if 'import asyncio' in source or 'from asyncio' in source:
+            ver = sys.version_info
+            if ver[0] < 3 or ver[1] < 5:
+                return orig_compile('', filename, *args)
+            else:
+                raise
+        else:
+            raise
+
+    return result
+
+
+__builtin__.compile = my_compile
 
 DLL_EXCLUDES = [
     "DINPUT8.dll",

--- a/_build/builder/CheckDependencies.py
+++ b/_build/builder/CheckDependencies.py
@@ -259,7 +259,7 @@ DEPENDENCIES = [
     ModuleDependency(
         name = "Sphinx",
         module = "sphinx",
-        version = "1.3.5",
+        version = "1.7.5",
     ),
     StacklessDependency(),
     ModuleDependency(


### PR DESCRIPTION
This is a fix for jinja2 > 2.8 SyntaxError when p2exe is byte compiling the files. The traceback occurs because newer versions of jinja 2 have files that include asyncio code.

The way i wrote this fix is it will check the source for any reference to an import of asyncio and if founf it will check the python version. if asyncio is not supported for that version it will return an empty byte compiled file