### PR TITLE
[PowerDVD] Update to work with newer PowerDVD versions (v12+)

### DIFF
--- a/plugins/PowerDVD/__init__.py
+++ b/plugins/PowerDVD/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is a plugin for EventGhost.
-# Copyright © 2005-2016 EventGhost Project <http://www.eventghost.org/>
+# Copyright © 2005-2018 EventGhost Project <http://www.eventghost.net/>
 #
 # EventGhost is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free
@@ -20,58 +20,155 @@ import eg
 
 eg.RegisterPlugin(
     name="CyberLink PowerDVD",
-    description="Adds actions to control CyberLink PowerDVD 7 and 8.",
+    description="Adds actions to control CyberLink PowerDVD.",
     kind="program",
-    author="Bitmonster",
+    author="Bitmonster, GruberMarkus",
     guid="{4DBDFFA7-9E47-4782-B843-B196C74DE3EF}",
-    version="1.1",
+    version="2.0",
     createMacrosOnAdd=True,
 )
 
-ACTIONS = [
-    ("Play", "Play", "Plays media.", "{Return}"),
-    ("Pause", "Pause", "Pauses playback.", "{Space}"),
-    ("Stop", "Stop", "Stops playback.", "s"),
-    ("Menu", "Menu", "Accesses all available DVD menus.", "l"),
-    ("PreviousChapter", "Previous chapter", "Returns to previous chapter.", "p"),
-    ("NextChapter", "Next chapter", "Jumps to next chapter.", "n"),
-    ("StepBackward", "Step backward", "Goes to previous frame.", "e"),
-    ("StepForward", "Step forward", "Goes to next frame.", "t"),
-    ("ToggleFullscreen", "Toggle fullscreen", "Toggles between fullscreen and window mode.", "z"),
-    ("ToggleMute", "Toggle mute", "Mute volume.", "q"),
-    ("VolumeUp", "Volume up", "Increase volume.", "+"),
-    ("VolumeDown", "Volume down", "Decrease volume.", "-"),
-    ("NextAudioStream", "Next audio stream", "Switches among available audio streams.", "h"),
-    ("NextSubtitle", "Next subtitle", "Switches among available subtitles during playback.", "u"),
-    ("NextAngel", "Next angel", "Switches among available angles if any.", "a"),
-    ("SayItAgain", "Say-It-Again", "Repeats the last dialog.", "w"),
-    ("SeeItAll", "See-It-All", "Activates See-It-All function, refer to Blu-ray Disc Configuration.", "{LCtrl+S}"),
-    ("CaptureFrame", "Capture frame", "Captures video content as bitmap image files. (Not supported during HD DVD and Blu-ray Disc playback.)", "c"),
-    ("NavigationUp", "Navigation Up", "Navigates through disc menus.", "{Up}"),
-    ("NavigationDown", "Navigation Down", "Navigates through disc menus.", "{Down}"),
-    ("NavigationLeft", "Navigation Left", "Navigates through disc menus.", "{Left}"),
-    ("NavigationRight", "Navigation Right", "Navigates through disc menus.", "{Right}"),
-    ("NavigationEnter", "Navigation Enter", "Navigates through disc menus. (Has actually the same function as the Play action.)", "{Return}"),
-    ("Close", "Close", "Close PowerDVD.", "{Ctrl+x}"),
+
+AudioActions = [
+    ("VolumeUp", "Volume Up", "Increase audio volume.", "+"),
+    ("VolumeDown", "Volume Down", "Decrease audio volume.", "-"),
+    ("ToggleMute", "Toggle Mute", "Mute on/off.", "q"),
+    ("SwitchAudioChannels", "Switch Audio Channels", "Switch among available audio channels.", "h"),
+    ("ToggleSecondaryAudio", "Toggle Secondary Audio", "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
 ]
 
+VideoPlayActions = [
+    ("TogglePlayPause", "Toggle Play/Pause", "Play/pause media playback.", "{Space}"),
+    ("Stop", "Stop", "Stop playback.", "s"),
+    ("FastForward", "Fast Forward", "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
+    ("SlowForward", "Slow Forward", "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
+    ("StepForward", "Step Forward", "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
+    ("Rewind", "Rewind", "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
+    ("StepBackward", "Step Backward", "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
+    ("NextChapter", "Next Chapter", "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
+    ("PreviousChapter", "Previous Chapter", "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
+    ("JumpBack8Seconds", "Jump back 8 seconds", "Jump back 8 seconds.", "{Ctrl+Left}"),
+    ("JumpForward30Seconds", "Jump forward 30 seconds", "Jump forward 30 seconds.", "{Ctrl+Right}"),
+    ("NextViewingAngle", "Next Viewing Angle", "Go to next available angle.", "a"),
+    ("ToggleSecondaryVideo", "Toggle Secondary Video", "Enable/disable secondary video.", "{Ctrl+v}"),
+]
 
-gWindowMatcher = eg.WindowMatcher('PowerDVD{*}.exe', 'CyberLink PowerDVD{*}')
+VideoSubtitleActions = [
+    ("TogglePrimarySubtitles", "Toggle Primary Subtitles And Language", "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
+    ("ToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language", "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
+    ("ToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language", "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
+    ("ChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position", "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
+]
+
+VideoMenuActions = [
+    ("DVDRootMenu", "DVD Root Menu", "Go to the DVD root menu.", "j"),
+    ("AllDiscMenus", "All Disc Menus", "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
+    ("PlaybackMenu", "Playback Menu", "Displays the playback menu.", "{Ctrl+p}"),
+    ("ResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu", "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
+    ("GoToBookmark", "Go To Bookmark", "Go to bookmark.", "g"),
+    ("DVDMenu", "DVD Menu", "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
+    ("MenuUp", "Menu Up", "Navigate up in menus.", "r"),
+]
+
+PictureActions = [
+    ("RotateCounterclockwise", "Rotate Counterclockwise", "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
+    ("RotateClockwise", "Rotate Clockwise", "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
+    ("Snapshot", "Snapshot", "Take a photo snapshot.", "{Ctrl+c}"),
+]
+
+MusicActions = [
+    ("Repeat", "Repeat", "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
+    ("Shuffle", "Shuffle", "Turn music shuffle on/off.", "v"),
+    ("SwitchKaraokeModes", "Switch Karaoke Modes", "Switches among karaoke modes.", "k"),
+    ("MiniPlayer", "Mini Player", "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
+    ("A-BRepeatDialogWindow", "A-B Repeat Dialog Window", "Open A-B Repeat dialog window.", "x"),
+]
+
+NavigationActions = [
+    ("Left", "Left", "Navigate left in menus.", "{Left}"),
+    ("Right", "Right", "Navigate right in menus.", "{Right}"),
+    ("Up", "Up", "Navigate up in menus.", "{Up}"),
+    ("Down", "Down", "Navigate down in menus.", "{Down}"),
+    ("Enter", "Enter", "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
+    ("CloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen", "Close active dialog or exit full screen mode.", "{Esc}"),
+    ("GreenButton", "Green Button", "Green button on a remote control.", "{F10}"),
+    ("YellowButton", "Yellow Button", "Yellow button on a remote control.", "{F11}"),
+    ("BlueButton", "Blue Button", "Blue button on a remote control.", "{F12}"),
+    ("RedButton", "Red Button", "Red button on a remote control.", "{F9}"),
+]
+
+ProgramManagementActions = [
+    ("Maximize", "Maximize", "Maximize the CyberLink PowerDVD program.", "{F5}"),
+    ("Minimize", "Minimize", "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
+    ("ToggleFullscreen", "Toggle Fullscreen", "Toggle playback to/from full screen mode.", "z"),
+    ("IncreaseScreenBrightness", "Increase Screen Brightness", "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
+    ("DecreaseScreenBrightness", "Decrease Screen Brightness", "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
+    ("EjectDisc", "Eject Disc", "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
+    ("Settings", "Settings", "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
+    ("Help", "Help", "Open PowerDVD help.", "{F1}"),
+    ("About", "About", "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
+    ("AccessUpgradeInfo", "Access Upgrade Info", "Access PowerDVD upgrade information dialog.", "i"),
+    ("ClosePowerDVD", "Close PowerDVD", "Close PowerDVD.", "{Alt+F4}"),
+]
+
 
 
 class ActionPrototype(eg.ActionBase):
 
     def __call__(self):
-        hwnds = gWindowMatcher()
+        #
+        # Get the window handle (HWND) of the PowerDVD main window and the HWND of the PowerDVD player window.
+        #     When PowerDVD is running, the main window is not hidden and always has an HWND.
+        #     The player window is hidden and only exists when playback has begun.
+        # Combine the two lists, the main window being the first entry.
+        # If the list is empty, raise an error.
+        # Else, send the key stroke to the last element in the list
+        # (i.e., to the player window when playback has begun, else to the main window).
+        #
+        # This also works when PowerDVD is running in the background.
+        #
+        #
+        # AutoHotKey searches HWNDs differently, requiring only two lines of code to find the window
+        # and sending a key to it (also works when PowerDVD is in the background).
+        # AHK code for toggling play/pause:
+        #     ControlGet, OutputVar, Hwnd,,, PowerDVD
+        #     ControlSend, , {space}, ahk_id %OutputVar%
+        #
+
+	gWindowMatcherMainWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', None, None, None, 1, "false", 0, None)
+	gWindowMatcherPlayerWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', '{*}', '{*}', '{*}', 1, "true", 0, None)
+
+        hwnds = gWindowMatcherMainWindow() + gWindowMatcherPlayerWindow()
+
         if hwnds:
-            eg.SendKeys(hwnds[0], self.value)
+            eg.SendKeys(hwnds[-1], self.value)
         else:
             raise self.Exceptions.ProgramNotRunning
 
 
-
-class PowerDvd(eg.PluginBase):
+class PowerDVD(eg.PluginBase):
 
     def __init__(self):
-        self.AddActionsFromList(ACTIONS, ActionPrototype)
+        group = self.AddGroup("Audio", "")
+        group.AddActionsFromList(AudioActions, ActionPrototype)
 
+        group = self.AddGroup("Video Playback", "")
+        group.AddActionsFromList(VideoPlayActions, ActionPrototype)
+
+        group = self.AddGroup("Video Subtitles", "")
+        group.AddActionsFromList(VideoSubtitleActions, ActionPrototype)
+
+        group = self.AddGroup("Video Menus", "")
+        group.AddActionsFromList(VideoMenuActions, ActionPrototype)
+
+        group = self.AddGroup("Pictures", "")
+        group.AddActionsFromList(PictureActions, ActionPrototype)
+
+        group = self.AddGroup("Music", "")
+        group.AddActionsFromList(MusicActions, ActionPrototype)
+
+        group = self.AddGroup("General Navigation", "")
+        group.AddActionsFromList(NavigationActions, ActionPrototype)
+
+        group = self.AddGroup("General Program Management", "")
+        group.AddActionsFromList(ProgramManagementActions, ActionPrototype)

--- a/plugins/PowerDVD/__init__.py
+++ b/plugins/PowerDVD/__init__.py
@@ -29,89 +29,85 @@ eg.RegisterPlugin(
 )
 
 
-AudioActions = [
-    ("VolumeUp", "Volume Up", "Increase audio volume.", "+"),
-    ("VolumeDown", "Volume Down", "Decrease audio volume.", "-"),
-    ("ToggleMute", "Toggle Mute", "Mute on/off.", "q"),
-    ("SwitchAudioChannels", "Switch Audio Channels", "Switch among available audio channels.", "h"),
-    ("ToggleSecondaryAudio", "Toggle Secondary Audio", "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
-]
+action_list = {
+    'AudioActions': [
+        ("VolumeUp", "Volume Up", "Increase audio volume.", "+"),
+        ("VolumeDown", "Volume Down", "Decrease audio volume.", "-"),
+        ("ToggleMute", "Toggle Mute", "Mute on/off.", "q"),
+        ("SwitchAudioChannels", "Switch Audio Channels", "Switch among available audio channels.", "h"),
+        ("ToggleSecondaryAudio", "Toggle Secondary Audio", "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
+    ],
+    'VideoPlayActions': [
+        ("TogglePlayPause", "Toggle Play/Pause", "Play/pause media playback.", "{Space}"),
+        ("Stop", "Stop", "Stop playback.", "s"),
+        ("FastForward", "Fast Forward", "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
+        ("SlowForward", "Slow Forward", "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
+        ("StepForward", "Step Forward", "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
+        ("Rewind", "Rewind", "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
+        ("StepBackward", "Step Backward", "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
+        ("NextChapter", "Next Chapter", "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
+        ("PreviousChapter", "Previous Chapter", "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
+        ("JumpBack8Seconds", "Jump back 8 seconds", "Jump back 8 seconds.", "{Ctrl+Left}"),
+        ("JumpForward30Seconds", "Jump forward 30 seconds", "Jump forward 30 seconds.", "{Ctrl+Right}"),
+        ("NextViewingAngle", "Next Viewing Angle", "Go to next available angle.", "a"),
+        ("ToggleSecondaryVideo", "Toggle Secondary Video", "Enable/disable secondary video.", "{Ctrl+v}"),
+    ],
+    'VideoSubtitleActions': [
+        ("TogglePrimarySubtitles", "Toggle Primary Subtitles And Language", "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
+        ("ToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language", "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
+        ("ToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language", "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
+        ("ChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position", "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
+    ],
+    'VideoMenuActions': [
+        ("DVDRootMenu", "DVD Root Menu", "Go to the DVD root menu.", "j"),
+        ("AllDiscMenus", "All Disc Menus", "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
+        ("PlaybackMenu", "Playback Menu", "Displays the playback menu.", "{Ctrl+p}"),
+        ("ResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu", "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
+        ("GoToBookmark", "Go To Bookmark", "Go to bookmark.", "g"),
+        ("DVDMenu", "DVD Menu", "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
+        ("MenuUp", "Menu Up", "Navigate up in menus.", "r"),
+    ],
+    'PictureActions': [
+        ("RotateCounterclockwise", "Rotate Counterclockwise", "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
+        ("RotateClockwise", "Rotate Clockwise", "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
+        ("Snapshot", "Snapshot", "Take a photo snapshot.", "{Ctrl+c}"),
+    ],
+    'MusicActions': [
+        ("Repeat", "Repeat", "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
+        ("Shuffle", "Shuffle", "Turn music shuffle on/off.", "v"),
+        ("SwitchKaraokeModes", "Switch Karaoke Modes", "Switches among karaoke modes.", "k"),
+        ("MiniPlayer", "Mini Player", "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
+        ("A-BRepeatDialogWindow", "A-B Repeat Dialog Window", "Open A-B Repeat dialog window.", "x"),
+    ],
+    'NavigationActions': [
+        ("Left", "Left", "Navigate left in menus.", "{Left}"),
+        ("Right", "Right", "Navigate right in menus.", "{Right}"),
+        ("Up", "Up", "Navigate up in menus.", "{Up}"),
+        ("Down", "Down", "Navigate down in menus.", "{Down}"),
+        ("Enter", "Enter", "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
+        ("CloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen", "Close active dialog or exit full screen mode.", "{Esc}"),
+        ("GreenButton", "Green Button", "Green button on a remote control.", "{F10}"),
+        ("YellowButton", "Yellow Button", "Yellow button on a remote control.", "{F11}"),
+        ("BlueButton", "Blue Button", "Blue button on a remote control.", "{F12}"),
+        ("RedButton", "Red Button", "Red button on a remote control.", "{F9}"),
+    ],
+    'ProgramManagementActions': [
+        ("Maximize", "Maximize", "Maximize the CyberLink PowerDVD program.", "{F5}"),
+        ("Minimize", "Minimize", "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
+        ("ToggleFullscreen", "Toggle Fullscreen", "Toggle playback to/from full screen mode.", "z"),
+        ("IncreaseScreenBrightness", "Increase Screen Brightness", "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
+        ("DecreaseScreenBrightness", "Decrease Screen Brightness", "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
+        ("EjectDisc", "Eject Disc", "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
+        ("Settings", "Settings", "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
+        ("Help", "Help", "Open PowerDVD help.", "{F1}"),
+        ("About", "About", "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
+        ("AccessUpgradeInfo", "Access Upgrade Info", "Access PowerDVD upgrade information dialog.", "i"),
+        ("ClosePowerDVD", "Close PowerDVD", "Close PowerDVD.", "{Alt+F4}"),
+    ]
+}
 
-VideoPlayActions = [
-    ("TogglePlayPause", "Toggle Play/Pause", "Play/pause media playback.", "{Space}"),
-    ("Stop", "Stop", "Stop playback.", "s"),
-    ("FastForward", "Fast Forward", "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
-    ("SlowForward", "Slow Forward", "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
-    ("StepForward", "Step Forward", "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
-    ("Rewind", "Rewind", "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
-    ("StepBackward", "Step Backward", "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
-    ("NextChapter", "Next Chapter", "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
-    ("PreviousChapter", "Previous Chapter", "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
-    ("JumpBack8Seconds", "Jump back 8 seconds", "Jump back 8 seconds.", "{Ctrl+Left}"),
-    ("JumpForward30Seconds", "Jump forward 30 seconds", "Jump forward 30 seconds.", "{Ctrl+Right}"),
-    ("NextViewingAngle", "Next Viewing Angle", "Go to next available angle.", "a"),
-    ("ToggleSecondaryVideo", "Toggle Secondary Video", "Enable/disable secondary video.", "{Ctrl+v}"),
-]
-
-VideoSubtitleActions = [
-    ("TogglePrimarySubtitles", "Toggle Primary Subtitles And Language", "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
-    ("ToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language", "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
-    ("ToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language", "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
-    ("ChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position", "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
-]
-
-VideoMenuActions = [
-    ("DVDRootMenu", "DVD Root Menu", "Go to the DVD root menu.", "j"),
-    ("AllDiscMenus", "All Disc Menus", "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
-    ("PlaybackMenu", "Playback Menu", "Displays the playback menu.", "{Ctrl+p}"),
-    ("ResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu", "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
-    ("GoToBookmark", "Go To Bookmark", "Go to bookmark.", "g"),
-    ("DVDMenu", "DVD Menu", "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
-    ("MenuUp", "Menu Up", "Navigate up in menus.", "r"),
-]
-
-PictureActions = [
-    ("RotateCounterclockwise", "Rotate Counterclockwise", "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
-    ("RotateClockwise", "Rotate Clockwise", "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
-    ("Snapshot", "Snapshot", "Take a photo snapshot.", "{Ctrl+c}"),
-]
-
-MusicActions = [
-    ("Repeat", "Repeat", "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
-    ("Shuffle", "Shuffle", "Turn music shuffle on/off.", "v"),
-    ("SwitchKaraokeModes", "Switch Karaoke Modes", "Switches among karaoke modes.", "k"),
-    ("MiniPlayer", "Mini Player", "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
-    ("A-BRepeatDialogWindow", "A-B Repeat Dialog Window", "Open A-B Repeat dialog window.", "x"),
-]
-
-NavigationActions = [
-    ("Left", "Left", "Navigate left in menus.", "{Left}"),
-    ("Right", "Right", "Navigate right in menus.", "{Right}"),
-    ("Up", "Up", "Navigate up in menus.", "{Up}"),
-    ("Down", "Down", "Navigate down in menus.", "{Down}"),
-    ("Enter", "Enter", "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
-    ("CloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen", "Close active dialog or exit full screen mode.", "{Esc}"),
-    ("GreenButton", "Green Button", "Green button on a remote control.", "{F10}"),
-    ("YellowButton", "Yellow Button", "Yellow button on a remote control.", "{F11}"),
-    ("BlueButton", "Blue Button", "Blue button on a remote control.", "{F12}"),
-    ("RedButton", "Red Button", "Red button on a remote control.", "{F9}"),
-]
-
-ProgramManagementActions = [
-    ("Maximize", "Maximize", "Maximize the CyberLink PowerDVD program.", "{F5}"),
-    ("Minimize", "Minimize", "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
-    ("ToggleFullscreen", "Toggle Fullscreen", "Toggle playback to/from full screen mode.", "z"),
-    ("IncreaseScreenBrightness", "Increase Screen Brightness", "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
-    ("DecreaseScreenBrightness", "Decrease Screen Brightness", "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
-    ("EjectDisc", "Eject Disc", "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
-    ("Settings", "Settings", "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
-    ("Help", "Help", "Open PowerDVD help.", "{F1}"),
-    ("About", "About", "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
-    ("AccessUpgradeInfo", "Access Upgrade Info", "Access PowerDVD upgrade information dialog.", "i"),
-    ("ClosePowerDVD", "Close PowerDVD", "Close PowerDVD.", "{Alt+F4}"),
-]
-
-
+gWindowMatcherMainWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', None, None, None, 1, "false", 0, None)
+gWindowMatcherPlayerWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', '{*}', '{*}', '{*}', 1, "true", 0, None)
 
 class ActionPrototype(eg.ActionBase):
 
@@ -135,9 +131,6 @@ class ActionPrototype(eg.ActionBase):
         #     ControlSend, , {space}, ahk_id %OutputVar%
         #
 
-	gWindowMatcherMainWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', None, None, None, 1, "false", 0, None)
-	gWindowMatcherPlayerWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', '{*}', '{*}', '{*}', 1, "true", 0, None)
-
         hwnds = gWindowMatcherMainWindow() + gWindowMatcherPlayerWindow()
 
         if hwnds:
@@ -149,26 +142,6 @@ class ActionPrototype(eg.ActionBase):
 class PowerDVD(eg.PluginBase):
 
     def __init__(self):
-        group = self.AddGroup("Audio", "")
-        group.AddActionsFromList(AudioActions, ActionPrototype)
-
-        group = self.AddGroup("Video Playback", "")
-        group.AddActionsFromList(VideoPlayActions, ActionPrototype)
-
-        group = self.AddGroup("Video Subtitles", "")
-        group.AddActionsFromList(VideoSubtitleActions, ActionPrototype)
-
-        group = self.AddGroup("Video Menus", "")
-        group.AddActionsFromList(VideoMenuActions, ActionPrototype)
-
-        group = self.AddGroup("Pictures", "")
-        group.AddActionsFromList(PictureActions, ActionPrototype)
-
-        group = self.AddGroup("Music", "")
-        group.AddActionsFromList(MusicActions, ActionPrototype)
-
-        group = self.AddGroup("General Navigation", "")
-        group.AddActionsFromList(NavigationActions, ActionPrototype)
-
-        group = self.AddGroup("General Program Management", "")
-        group.AddActionsFromList(ProgramManagementActions, ActionPrototype)
+        for grp, actions in action_list.iteritems():
+            group = self.AddGroup(grp, "")
+            group.AddActionsFromList(actions, ActionPrototype)

--- a/plugins/PowerDVD/__init__.py
+++ b/plugins/PowerDVD/__init__.py
@@ -18,6 +18,7 @@
 
 import eg
 
+
 eg.RegisterPlugin(
     name="CyberLink PowerDVD",
     description="Adds actions to control CyberLink PowerDVD.",
@@ -29,90 +30,13 @@ eg.RegisterPlugin(
 )
 
 
-action_list = {
-    'AudioActions': [
-        ("VolumeUp", "Volume Up", "Increase audio volume.", "+"),
-        ("VolumeDown", "Volume Down", "Decrease audio volume.", "-"),
-        ("ToggleMute", "Toggle Mute", "Mute on/off.", "q"),
-        ("SwitchAudioChannels", "Switch Audio Channels", "Switch among available audio channels.", "h"),
-        ("ToggleSecondaryAudio", "Toggle Secondary Audio", "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
-    ],
-    'VideoPlayActions': [
-        ("TogglePlayPause", "Toggle Play/Pause", "Play/pause media playback.", "{Space}"),
-        ("Stop", "Stop", "Stop playback.", "s"),
-        ("FastForward", "Fast Forward", "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
-        ("SlowForward", "Slow Forward", "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
-        ("StepForward", "Step Forward", "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
-        ("Rewind", "Rewind", "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
-        ("StepBackward", "Step Backward", "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
-        ("NextChapter", "Next Chapter", "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
-        ("PreviousChapter", "Previous Chapter", "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
-        ("JumpBack8Seconds", "Jump back 8 seconds", "Jump back 8 seconds.", "{Ctrl+Left}"),
-        ("JumpForward30Seconds", "Jump forward 30 seconds", "Jump forward 30 seconds.", "{Ctrl+Right}"),
-        ("NextViewingAngle", "Next Viewing Angle", "Go to next available angle.", "a"),
-        ("ToggleSecondaryVideo", "Toggle Secondary Video", "Enable/disable secondary video.", "{Ctrl+v}"),
-    ],
-    'VideoSubtitleActions': [
-        ("TogglePrimarySubtitles", "Toggle Primary Subtitles And Language", "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
-        ("ToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language", "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
-        ("ToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language", "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
-        ("ChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position", "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
-    ],
-    'VideoMenuActions': [
-        ("DVDRootMenu", "DVD Root Menu", "Go to the DVD root menu.", "j"),
-        ("AllDiscMenus", "All Disc Menus", "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
-        ("PlaybackMenu", "Playback Menu", "Displays the playback menu.", "{Ctrl+p}"),
-        ("ResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu", "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
-        ("GoToBookmark", "Go To Bookmark", "Go to bookmark.", "g"),
-        ("DVDMenu", "DVD Menu", "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
-        ("MenuUp", "Menu Up", "Navigate up in menus.", "r"),
-    ],
-    'PictureActions': [
-        ("RotateCounterclockwise", "Rotate Counterclockwise", "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
-        ("RotateClockwise", "Rotate Clockwise", "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
-        ("Snapshot", "Snapshot", "Take a photo snapshot.", "{Ctrl+c}"),
-    ],
-    'MusicActions': [
-        ("Repeat", "Repeat", "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
-        ("Shuffle", "Shuffle", "Turn music shuffle on/off.", "v"),
-        ("SwitchKaraokeModes", "Switch Karaoke Modes", "Switches among karaoke modes.", "k"),
-        ("MiniPlayer", "Mini Player", "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
-        ("A-BRepeatDialogWindow", "A-B Repeat Dialog Window", "Open A-B Repeat dialog window.", "x"),
-    ],
-    'NavigationActions': [
-        ("Left", "Left", "Navigate left in menus.", "{Left}"),
-        ("Right", "Right", "Navigate right in menus.", "{Right}"),
-        ("Up", "Up", "Navigate up in menus.", "{Up}"),
-        ("Down", "Down", "Navigate down in menus.", "{Down}"),
-        ("Enter", "Enter", "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
-        ("CloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen", "Close active dialog or exit full screen mode.", "{Esc}"),
-        ("GreenButton", "Green Button", "Green button on a remote control.", "{F10}"),
-        ("YellowButton", "Yellow Button", "Yellow button on a remote control.", "{F11}"),
-        ("BlueButton", "Blue Button", "Blue button on a remote control.", "{F12}"),
-        ("RedButton", "Red Button", "Red button on a remote control.", "{F9}"),
-    ],
-    'ProgramManagementActions': [
-        ("Maximize", "Maximize", "Maximize the CyberLink PowerDVD program.", "{F5}"),
-        ("Minimize", "Minimize", "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
-        ("ToggleFullscreen", "Toggle Fullscreen", "Toggle playback to/from full screen mode.", "z"),
-        ("IncreaseScreenBrightness", "Increase Screen Brightness", "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
-        ("DecreaseScreenBrightness", "Decrease Screen Brightness", "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
-        ("EjectDisc", "Eject Disc", "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
-        ("Settings", "Settings", "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
-        ("Help", "Help", "Open PowerDVD help.", "{F1}"),
-        ("About", "About", "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
-        ("AccessUpgradeInfo", "Access Upgrade Info", "Access PowerDVD upgrade information dialog.", "i"),
-        ("ClosePowerDVD", "Close PowerDVD", "Close PowerDVD.", "{Alt+F4}"),
-    ]
-}
-
 gWindowMatcherMainWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', None, None, None, 1, "false", 0, None)
 gWindowMatcherPlayerWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', '{*}', '{*}', '{*}', 1, "true", 0, None)
 
-class ActionPrototype(eg.ActionBase):
+
+class SendAction(eg.ActionBase):
 
     def __call__(self):
-        #
         # Get the window handle (HWND) of the PowerDVD main window and the HWND of the PowerDVD player window.
         #     When PowerDVD is running, the main window is not hidden and always has an HWND.
         #     The player window is hidden and only exists when playback has begun.
@@ -129,7 +53,6 @@ class ActionPrototype(eg.ActionBase):
         # AHK code for toggling play/pause:
         #     ControlGet, OutputVar, Hwnd,,, PowerDVD
         #     ControlSend, , {space}, ahk_id %OutputVar%
-        #
 
         hwnds = gWindowMatcherMainWindow() + gWindowMatcherPlayerWindow()
 
@@ -139,9 +62,85 @@ class ActionPrototype(eg.ActionBase):
             raise self.Exceptions.ProgramNotRunning
 
 
+ACTION_LIST = (
+    (eg.ActionGroup, 'AudioActions', 'Audio Actions', 'Audio Actions', (
+        (SendAction, "fnVolumeUp", "Volume Up", "Increase audio volume.", "+"),
+        (SendAction, "fnVolumeDown", "Volume Down", "Decrease audio volume.", "-"),
+        (SendAction, "fnToggleMute", "Toggle Mute", "Mute on/off.", "q"),
+        (SendAction, "fnSwitchAudioChannels", "Switch Audio Channels", "Switch among available audio channels.", "h"),
+        (SendAction, "fnToggleSecondaryAudio", "Toggle Secondary Audio", "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
+    )),
+    (eg.ActionGroup, 'VideoPlayActions', 'Video Play Actions', 'Video Play Actions', (
+        (SendAction, "fnTogglePlayPause", "Toggle Play/Pause", "Play/pause media playback.", "{Space}"),
+        (SendAction, "fnStop", "Stop", "Stop playback.", "s"),
+        (SendAction, "fnFastForward", "Fast Forward", "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
+        (SendAction, "fnSlowForward", "Slow Forward", "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
+        (SendAction, "fnStepForward", "Step Forward", "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
+        (SendAction, "fnRewind", "Rewind", "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
+        (SendAction, "fnStepBackward", "Step Backward", "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
+        (SendAction, "fnNextChapter", "Next Chapter", "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
+        (SendAction, "fnPreviousChapter", "Previous Chapter", "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
+        (SendAction, "fnJumpBack8Seconds", "Jump back 8 seconds", "Jump back 8 seconds.", "{Ctrl+Left}"),
+        (SendAction, "fnJumpForward30Seconds", "Jump forward 30 seconds", "Jump forward 30 seconds.", "{Ctrl+Right}"),
+        (SendAction, "fnNextViewingAngle", "Next Viewing Angle", "Go to next available angle.", "a"),
+        (SendAction, "fnToggleSecondaryVideo", "Toggle Secondary Video", "Enable/disable secondary video.", "{Ctrl+v}"),
+    )),
+    (eg.ActionGroup, 'VideoSubtitleActions', 'Video Subtitle Actions', 'Video Subtitle Actions', (
+        (SendAction, "fnTogglePrimarySubtitles", "Toggle Primary Subtitles And Language", "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
+        (SendAction, "fnToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language", "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
+        (SendAction, "fnToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language", "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
+        (SendAction, "fnChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position", "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
+    )),
+    (eg.ActionGroup, 'VideoMenuActions', 'Video Menu Actions', 'Video Menu Actions', (
+        (SendAction, "fnDVDRootMenu", "DVD Root Menu", "Go to the DVD root menu.", "j"),
+        (SendAction, "fnAllDiscMenus", "All Disc Menus", "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
+        (SendAction, "fnPlaybackMenu", "Playback Menu", "Displays the playback menu.", "{Ctrl+p}"),
+        (SendAction, "fnResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu", "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
+        (SendAction, "fnGoToBookmark", "Go To Bookmark", "Go to bookmark.", "g"),
+        (SendAction, "fnDVDMenu", "DVD Menu", "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
+        (SendAction, "fnMenuUp", "Menu Up", "Navigate up in menus.", "r"),
+    )),
+    (eg.ActionGroup, 'PictureActions', 'Picture Actions', 'Picture Actions', (
+        (SendAction, "fnRotateCounterclockwise", "Rotate Counterclockwise", "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
+        (SendAction, "fnRotateClockwise", "Rotate Clockwise", "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
+        (SendAction, "fnSnapshot", "Snapshot", "Take a photo snapshot.", "{Ctrl+c}"),
+    )),
+    (eg.ActionGroup, 'MusicActions', 'Music Actions', 'Music Actions', (
+        (SendAction, "fnRepeat", "Repeat", "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
+        (SendAction, "fnShuffle", "Shuffle", "Turn music shuffle on/off.", "v"),
+        (SendAction, "fnSwitchKaraokeModes", "Switch Karaoke Modes", "Switches among karaoke modes.", "k"),
+        (SendAction, "fnMiniPlayer", "Mini Player", "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
+        (SendAction, "fnA-BRepeatDialogWindow", "A-B Repeat Dialog Window", "Open A-B Repeat dialog window.", "x"),
+    )),
+    (eg.ActionGroup, 'NavigationActions', 'Navigation Actions', 'Navigation Actions', (
+        (SendAction, "fnLeft", "Left", "Navigate left in menus.", "{Left}"),
+        (SendAction, "fnRight", "Right", "Navigate right in menus.", "{Right}"),
+        (SendAction, "fnUp", "Up", "Navigate up in menus.", "{Up}"),
+        (SendAction, "fnDown", "Down", "Navigate down in menus.", "{Down}"),
+        (SendAction, "fnEnter", "Enter", "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
+        (SendAction, "fnCloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen", "Close active dialog or exit full screen mode.", "{Esc}"),
+        (SendAction, "fnGreenButton", "Green Button", "Green button on a remote control.", "{F10}"),
+        (SendAction, "fnYellowButton", "Yellow Button", "Yellow button on a remote control.", "{F11}"),
+        (SendAction, "fnBlueButton", "Blue Button", "Blue button on a remote control.", "{F12}"),
+        (SendAction, "fnRedButton", "Red Button", "Red button on a remote control.", "{F9}"),
+    )),
+    (eg.ActionGroup, 'ProgramManagementActions', 'Program Management Actions', 'Program Management Actions', (
+        (SendAction, "fnMaximize", "Maximize", "Maximize the CyberLink PowerDVD program.", "{F5}"),
+        (SendAction, "fnMinimize", "Minimize", "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
+        (SendAction, "fnToggleFullscreen", "Toggle Fullscreen", "Toggle playback to/from full screen mode.", "z"),
+        (SendAction, "fnIncreaseScreenBrightness", "Increase Screen Brightness", "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
+        (SendAction, "fnDecreaseScreenBrightness", "Decrease Screen Brightness", "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
+        (SendAction, "fnEjectDisc", "Eject Disc", "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
+        (SendAction, "fnSettings", "Settings", "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
+        (SendAction, "fnHelp", "Help", "Open PowerDVD help.", "{F1}"),
+        (SendAction, "fnAbout", "About", "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
+        (SendAction, "fnAccessUpgradeInfo", "Access Upgrade Info", "Access PowerDVD upgrade information dialog.", "i"),
+        (SendAction, "fnClose", "Close PowerDVD", "Close PowerDVD.", "{Alt+F4}"),
+    ))
+)
+
+
 class PowerDVD(eg.PluginBase):
 
     def __init__(self):
-        for grp, actions in action_list.iteritems():
-            group = self.AddGroup(grp, "")
-            group.AddActionsFromList(actions, ActionPrototype)
+        self.AddActionsFromList(ACTION_LIST)


### PR DESCRIPTION
The exising plugin does not work with newer PowerDVD versions (at least from version 12 upwards).

This update makes PowerDVD 18 controllable from within EventGhost. It is probably also compatible with earlier versions of PowerDVD.