### PR TITLE
[PowerDVD] switch from WindowMatcher to ctypes, PEP8 formatting

### DIFF
--- a/plugins/PowerDVD/__init__.py
+++ b/plugins/PowerDVD/__init__.py
@@ -25,7 +25,7 @@ eg.RegisterPlugin(
     kind="program",
     author="Bitmonster, GruberMarkus",
     guid="{4DBDFFA7-9E47-4782-B843-B196C74DE3EF}",
-    version="2.1",
+    version="3.0",
     createMacrosOnAdd=True,
 )
 

--- a/plugins/PowerDVD/__init__.py
+++ b/plugins/PowerDVD/__init__.py
@@ -25,13 +25,12 @@ eg.RegisterPlugin(
     kind="program",
     author="Bitmonster, GruberMarkus",
     guid="{4DBDFFA7-9E47-4782-B843-B196C74DE3EF}",
-    version="2.0",
+    version="2.1",
     createMacrosOnAdd=True,
 )
 
 
-gWindowMatcherMainWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', None, None, None, 1, "false", 0, None)
-gWindowMatcherPlayerWindow = eg.WindowMatcher('PowerDVD{*}.exe', 'PowerDVD', '{*}', '{*}', '{*}', 1, "true", 0, None)
+import ctypes
 
 
 class SendAction(eg.ActionBase):
@@ -54,7 +53,19 @@ class SendAction(eg.ActionBase):
         #     ControlGet, OutputVar, Hwnd,,, PowerDVD
         #     ControlSend, , {space}, ahk_id %OutputVar%
 
-        hwnds = gWindowMatcherMainWindow() + gWindowMatcherPlayerWindow()
+        hwnds = []
+
+        # Main window
+        hwndMainWindow = ctypes.windll.user32.FindWindowA(None, "PowerDVD")
+        if hwndMainWindow:
+            hwnds.append(hwndMainWindow)
+
+        # Player window
+        if hwndMainWindow:
+            hwndPlayerWindow = ctypes.windll.user32.FindWindowExA(
+                hwndMainWindow, 0, 0, 0)
+            if hwndPlayerWindow:
+                hwnds.append(hwndPlayerWindow)
 
         if hwnds:
             eg.SendKeys(hwnds[-1], self.value)
@@ -67,75 +78,122 @@ ACTION_LIST = (
         (SendAction, "fnVolumeUp", "Volume Up", "Increase audio volume.", "+"),
         (SendAction, "fnVolumeDown", "Volume Down", "Decrease audio volume.", "-"),
         (SendAction, "fnToggleMute", "Toggle Mute", "Mute on/off.", "q"),
-        (SendAction, "fnSwitchAudioChannels", "Switch Audio Channels", "Switch among available audio channels.", "h"),
-        (SendAction, "fnToggleSecondaryAudio", "Toggle Secondary Audio", "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
+        (SendAction, "fnSwitchAudioChannels", "Switch Audio Channels",
+         "Switch among available audio channels.", "h"),
+        (SendAction, "fnToggleSecondaryAudio", "Toggle Secondary Audio",
+         "Enable/disable secondary audio for Blu-ray Disc movies.", "{Ctrl+d}"),
     )),
     (eg.ActionGroup, 'VideoPlayActions', 'Video Play Actions', 'Video Play Actions', (
-        (SendAction, "fnTogglePlayPause", "Toggle Play/Pause", "Play/pause media playback.", "{Space}"),
+        (SendAction, "fnTogglePlayPause", "Toggle Play/Pause",
+         "Play/pause media playback.", "{Space}"),
         (SendAction, "fnStop", "Stop", "Stop playback.", "s"),
-        (SendAction, "fnFastForward", "Fast Forward", "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
-        (SendAction, "fnSlowForward", "Slow Forward", "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
-        (SendAction, "fnStepForward", "Step Forward", "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
-        (SendAction, "fnRewind", "Rewind", "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
-        (SendAction, "fnStepBackward", "Step Backward", "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
-        (SendAction, "fnNextChapter", "Next Chapter", "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
-        (SendAction, "fnPreviousChapter", "Previous Chapter", "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
-        (SendAction, "fnJumpBack8Seconds", "Jump back 8 seconds", "Jump back 8 seconds.", "{Ctrl+Left}"),
-        (SendAction, "fnJumpForward30Seconds", "Jump forward 30 seconds", "Jump forward 30 seconds.", "{Ctrl+Right}"),
-        (SendAction, "fnNextViewingAngle", "Next Viewing Angle", "Go to next available angle.", "a"),
-        (SendAction, "fnToggleSecondaryVideo", "Toggle Secondary Video", "Enable/disable secondary video.", "{Ctrl+v}"),
+        (SendAction, "fnFastForward", "Fast Forward",
+         "Fast forward through media content. Press repeatedly to increase the fast forward speed.", "f"),
+        (SendAction, "fnSlowForward", "Slow Forward",
+         "Slow forward through media content. Press repeatedly to increase the slow forward speed.", "}"),
+        (SendAction, "fnStepForward", "Step Forward",
+         "Pause playback and go to the next frame of video. Press repeatedly to step forward through media one frame at a time.", "t"),
+        (SendAction, "fnRewind", "Rewind",
+         "Reverse through media content. Press repeatedly to increase the reverse speed.", "b"),
+        (SendAction, "fnStepBackward", "Step Backward",
+         "Pause playback and step backward. Press repeatedly to step backward through video content. Note: this feature is not available for some video file formats.", "e"),
+        (SendAction, "fnNextChapter", "Next Chapter",
+         "Go to the next chapter or media file in a playlist/folder. Also go to next song on a music disc.", "n"),
+        (SendAction, "fnPreviousChapter", "Previous Chapter",
+         "Return to previous chapter or media file in a playlist/folder. Also return to previous song on a music disc.", "p"),
+        (SendAction, "fnJumpBack8Seconds", "Jump back 8 seconds",
+         "Jump back 8 seconds.", "{Ctrl+Left}"),
+        (SendAction, "fnJumpForward30Seconds", "Jump forward 30 seconds",
+         "Jump forward 30 seconds.", "{Ctrl+Right}"),
+        (SendAction, "fnNextViewingAngle", "Next Viewing Angle",
+         "Go to next available angle.", "a"),
+        (SendAction, "fnToggleSecondaryVideo", "Toggle Secondary Video",
+         "Enable/disable secondary video.", "{Ctrl+v}"),
     )),
     (eg.ActionGroup, 'VideoSubtitleActions', 'Video Subtitle Actions', 'Video Subtitle Actions', (
-        (SendAction, "fnTogglePrimarySubtitles", "Toggle Primary Subtitles And Language", "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
-        (SendAction, "fnToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language", "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
-        (SendAction, "fnToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language", "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
-        (SendAction, "fnChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position", "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
+        (SendAction, "fnTogglePrimarySubtitles", "Toggle Primary Subtitles And Language",
+         "Enable/disable primary subtitles, toggle through languages.", "{Ctrl+g}"),
+        (SendAction, "fnToggleSecondarySubtitles", "Toggle Secondary Subtitles And Language",
+         "Enable/disable secondary subtitles, toggle through languages.", "{Ctrl+u}"),
+        (SendAction, "fnToggleEnhancedSubtitles", "Toggle Enhanced Subtitles And Language",
+         "Enable/disable enhanced subtitles, toggle through languages.", "{Ctrl+u}"),
+        (SendAction, "fnChangeSecondarySubtitlesPosition", "Change Secondary Subtitles Position",
+         "Change secondary subtitles position (Read-it-Clearly).", "{Ctrl+y}"),
     )),
     (eg.ActionGroup, 'VideoMenuActions', 'Video Menu Actions', 'Video Menu Actions', (
-        (SendAction, "fnDVDRootMenu", "DVD Root Menu", "Go to the DVD root menu.", "j"),
-        (SendAction, "fnAllDiscMenus", "All Disc Menus", "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
-        (SendAction, "fnPlaybackMenu", "Playback Menu", "Displays the playback menu.", "{Ctrl+p}"),
-        (SendAction, "fnResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu", "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
+        (SendAction, "fnDVDRootMenu", "DVD Root Menu",
+         "Go to the DVD root menu.", "j"),
+        (SendAction, "fnAllDiscMenus", "All Disc Menus",
+         "Access a menu that lets you quickly jump to one of the available disc menus.", "l"),
+        (SendAction, "fnPlaybackMenu", "Playback Menu",
+         "Displays the playback menu.", "{Ctrl+p}"),
+        (SendAction, "fnResumePlaybackFromInteractiveMenu", "Resume Playback From Interactive Menu",
+         "When the video playback is paused, but the interactive menu is active, this will resume the video.", "{Ctrl+w}"),
         (SendAction, "fnGoToBookmark", "Go To Bookmark", "Go to bookmark.", "g"),
-        (SendAction, "fnDVDMenu", "DVD Menu", "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
+        (SendAction, "fnDVDMenu", "DVD Menu",
+         "Provides access to DVD menu controls during DVD playback. During Blu-ray Disc playback pressing this button will display the pop-up menu.", "m"),
         (SendAction, "fnMenuUp", "Menu Up", "Navigate up in menus.", "r"),
     )),
     (eg.ActionGroup, 'PictureActions', 'Picture Actions', 'Picture Actions', (
-        (SendAction, "fnRotateCounterclockwise", "Rotate Counterclockwise", "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
-        (SendAction, "fnRotateClockwise", "Rotate Clockwise", "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
-        (SendAction, "fnSnapshot", "Snapshot", "Take a photo snapshot.", "{Ctrl+c}"),
+        (SendAction, "fnRotateCounterclockwise", "Rotate Counterclockwise",
+         "Rotate photo 90 degrees in the counterclockwise direction.", "{Ctrl+,"),
+        (SendAction, "fnRotateClockwise", "Rotate Clockwise",
+         "Rotate photo/video 90 degrees in the clockwise direction.", "{Ctrl+.}"),
+        (SendAction, "fnSnapshot", "Snapshot",
+         "Take a photo snapshot.", "{Ctrl+c}"),
     )),
     (eg.ActionGroup, 'MusicActions', 'Music Actions', 'Music Actions', (
-        (SendAction, "fnRepeat", "Repeat", "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
+        (SendAction, "fnRepeat", "Repeat",
+         "Repeat one or all of the media files in a folder/playlist.", "{Ctrl+r}"),
         (SendAction, "fnShuffle", "Shuffle", "Turn music shuffle on/off.", "v"),
-        (SendAction, "fnSwitchKaraokeModes", "Switch Karaoke Modes", "Switches among karaoke modes.", "k"),
-        (SendAction, "fnMiniPlayer", "Mini Player", "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
-        (SendAction, "fnA-BRepeatDialogWindow", "A-B Repeat Dialog Window", "Open A-B Repeat dialog window.", "x"),
+        (SendAction, "fnSwitchKaraokeModes", "Switch Karaoke Modes",
+         "Switches among karaoke modes.", "k"),
+        (SendAction, "fnMiniPlayer", "Mini Player",
+         "Switch to Mini Player mode during music playback.", "{Ctrl+m}"),
+        (SendAction, "fnA-BRepeatDialogWindow", "A-B Repeat Dialog Window",
+         "Open A-B Repeat dialog window.", "x"),
     )),
     (eg.ActionGroup, 'NavigationActions', 'Navigation Actions', 'Navigation Actions', (
         (SendAction, "fnLeft", "Left", "Navigate left in menus.", "{Left}"),
-        (SendAction, "fnRight", "Right", "Navigate right in menus.", "{Right}"),
+        (SendAction, "fnRight", "Right",
+         "Navigate right in menus.", "{Right}"),
         (SendAction, "fnUp", "Up", "Navigate up in menus.", "{Up}"),
         (SendAction, "fnDown", "Down", "Navigate down in menus.", "{Down}"),
-        (SendAction, "fnEnter", "Enter", "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
-        (SendAction, "fnCloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen", "Close active dialog or exit full screen mode.", "{Esc}"),
-        (SendAction, "fnGreenButton", "Green Button", "Green button on a remote control.", "{F10}"),
-        (SendAction, "fnYellowButton", "Yellow Button", "Yellow button on a remote control.", "{F11}"),
-        (SendAction, "fnBlueButton", "Blue Button", "Blue button on a remote control.", "{F12}"),
-        (SendAction, "fnRedButton", "Red Button", "Red button on a remote control.", "{F9}"),
+        (SendAction, "fnEnter", "Enter",
+         "Accepts the selected option when using the arrow keys to navigate menus.", "{Enter}"),
+        (SendAction, "fnCloseActiveDialogOrExitFullscreen", "Close Active Dialog Or Exit Fullscreen",
+         "Close active dialog or exit full screen mode.", "{Esc}"),
+        (SendAction, "fnGreenButton", "Green Button",
+         "Green button on a remote control.", "{F10}"),
+        (SendAction, "fnYellowButton", "Yellow Button",
+         "Yellow button on a remote control.", "{F11}"),
+        (SendAction, "fnBlueButton", "Blue Button",
+         "Blue button on a remote control.", "{F12}"),
+        (SendAction, "fnRedButton", "Red Button",
+         "Red button on a remote control.", "{F9}"),
     )),
     (eg.ActionGroup, 'ProgramManagementActions', 'Program Management Actions', 'Program Management Actions', (
-        (SendAction, "fnMaximize", "Maximize", "Maximize the CyberLink PowerDVD program.", "{F5}"),
-        (SendAction, "fnMinimize", "Minimize", "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
-        (SendAction, "fnToggleFullscreen", "Toggle Fullscreen", "Toggle playback to/from full screen mode.", "z"),
-        (SendAction, "fnIncreaseScreenBrightness", "Increase Screen Brightness", "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
-        (SendAction, "fnDecreaseScreenBrightness", "Decrease Screen Brightness", "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
-        (SendAction, "fnEjectDisc", "Eject Disc", "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
-        (SendAction, "fnSettings", "Settings", "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
+        (SendAction, "fnMaximize", "Maximize",
+         "Maximize the CyberLink PowerDVD program.", "{F5}"),
+        (SendAction, "fnMinimize", "Minimize",
+         "Minimize the CyberLink PowerDVD program.", "{Ctrl+n}"),
+        (SendAction, "fnToggleFullscreen", "Toggle Fullscreen",
+         "Toggle playback to/from full screen mode.", "z"),
+        (SendAction, "fnIncreaseScreenBrightness", "Increase Screen Brightness",
+         "Increase screen brightness on supported displays.", "{Ctrl+Up}"),
+        (SendAction, "fnDecreaseScreenBrightness", "Decrease Screen Brightness",
+         "Decrease screen brightness on supported displays.", "{Ctrl+Down}"),
+        (SendAction, "fnEjectDisc", "Eject Disc",
+         "Eject the disc in the selected disc drive.", "{Ctrl+e}"),
+        (SendAction, "fnSettings", "Settings",
+         "Open the PowerDVD settings window.", "{Ctrl+Shift+c}"),
         (SendAction, "fnHelp", "Help", "Open PowerDVD help.", "{F1}"),
-        (SendAction, "fnAbout", "About", "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
-        (SendAction, "fnAccessUpgradeInfo", "Access Upgrade Info", "Access PowerDVD upgrade information dialog.", "i"),
-        (SendAction, "fnClose", "Close PowerDVD", "Close PowerDVD.", "{Alt+F4}"),
+        (SendAction, "fnAbout", "About",
+         "Open the About PowerDVD window.", "{Ctrl+Shift+a}"),
+        (SendAction, "fnAccessUpgradeInfo", "Access Upgrade Info",
+         "Access PowerDVD upgrade information dialog.", "i"),
+        (SendAction, "fnClose", "Close PowerDVD",
+         "Close PowerDVD.", "{Alt+F4}"),
     ))
 )
 


### PR DESCRIPTION
* WindowMatcher is very slow, even with timeout specified, which may cause problems when system suspends or enters away mode. Switching to ctypes (FindWindow, FindWindowEx).
* PEP8 formatting rules applied.