### PR TITLE
[VLC] add 64 bit support, fix play, volup and voldown

### DIFF
--- a/plugins/VLC/__init__.py
+++ b/plugins/VLC/__init__.py
@@ -82,22 +82,18 @@ def GetVlcPath():
     """
     Tries to get the path of VLC's executable through querying the Windows
     registry.
+    Not querying HKLM\Software\VideoLAN\VLC to avoid multiple queries
+    neccessary due to registry virtualization on 64 bit systems.
     """
     try:
-        return _winreg.QueryValue(_winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\Classes\VLC.OPENFolder\shell\Open\command").split("\"")[1]
-    except WindowsError:
-        if "ProgramFiles(X86)" in os.environ:  # 64 bit Windows, indepedent from Python bitness
-            if os.path.exists(os.getenv("ProgramFiles") + "\\VideoLAN\\VLC\\vlc.exe"):  # check for 64 bit VLC in default install directory
-                return os.getenv("ProgramFiles") + "\\VideoLAN\\VLC\\vlc.exe"
-            elif os.path.exists(os.getenv("ProgramFiles(X86)") + "\\VideoLAN\\VLC\\vlc.exe"):  # check for 32 bit VLC in default install directory
-                return os.getenv("ProgramFiles(X86)") + "\\VideoLAN\\VLC\\vlc.exe"
-            else:
-                return None
-        else:  # 32 bit Windows, independent from Python bitness
-            if os.path.exists(os.getenv("ProgramFiles") + "\\VideoLAN\\VLC\\vlc.exe"):  # check for 64 bit VLC in default install directory
-                return os.getenv("ProgramFiles") + "\\VideoLAN\\VLC\\vlc.exe"
-            else:
-                return None
+        path = _winreg.QueryValue(_winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\Classes\VLC.OPENFolder\shell\Open\command").split("\"")[1]
+    except:
+        return None
+
+    if os.path.exists(path):
+            return path
+    else:
+        return None
             
 
 def GetChoices():

--- a/plugins/VLC/__init__.py
+++ b/plugins/VLC/__init__.py
@@ -670,7 +670,7 @@ ACTIONS = (
         'Play',
         'Play',
         'Start playing',
-        'pause'
+        'play'
     ),
     (
         ActionPrototype,
@@ -813,14 +813,14 @@ ACTIONS = (
         'VolumeUp',
         'Volume Up',
         'Volume up',
-        'volup'
+        'volup 1'
     ),
     (
         ActionPrototype,
         'VolumeDown',
         'Volume Down',
         'Volume down',
-        'voldown'
+        'voldown 1'
     ),
     (
         MyCommand,


### PR DESCRIPTION
- Add support for 64 bit VLC install directory detection via a registry query. 
- Switch to socket.sendall, as pure sendall is now deprecated.
- "volup" and "voldown" are no longer supported by VLC as standalone commands, they now require a parameter with the number of steps by which to increment or decrement the volume. E.g., "volup 1" to increase volume by one step.
- The play command now does what it says, that is start media playback. It no longer toggles between play and pause states, as there is a separate command for this. 
