### PR TITLE
[EventGhost] TriggerEvent: option to remove the 'Main' prefix

### DIFF
--- a/plugins/EventGhost/__init__.py
+++ b/plugins/EventGhost/__init__.py
@@ -814,8 +814,10 @@ class TriggerEvent(eg.ActionBase):
 
         queueEventCtrl.SetValue(queueEvent)
         restoreEventCtrl.SetValue(restoreEvent)
+        removeMainCtrl.SetValue(removeMain)
         queueEventCtrl.Enable(not waitTime)
         restoreEventCtrl.Enable(not waitTime and not queueEvent)
+        removeMainCtrl.Enable('.' in eventString)
 
         if not eventString:
             removeMainCtrl.Disable()
@@ -829,7 +831,7 @@ class TriggerEvent(eg.ActionBase):
             evt.Skip()
 
         eventStringCtrl.Bind(wx.EVT_TEXT, on_char)
-        
+
         def on_spin(evt):
             def check_spin():
                 value = bool(waitTimeCtrl.GetValue())


### PR DESCRIPTION
I added an option to the Trigger Event action to remove the main prefix.


Fixes #350 