### PR TITLE
Fix issue when locale has no translation (OptionsDialog.py), and right to left bug on (SpinNumCtrl.py)

### DIFF
--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -192,7 +192,6 @@ class OptionsDialog(eg.TaskletDialog):
             else:
                 languageChoice.Append(name)
         
-        # if no translation for language, default to English
         if config.language not in languageList:
             config.language='en_EN'
         

--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -191,6 +191,10 @@ class OptionsDialog(eg.TaskletDialog):
                 languageChoice.Append(name, bmp)
             else:
                 languageChoice.Append(name)
+        
+        if config.language not in languageList:
+            config.language='en_EN'
+        
         languageChoice.SetSelection(languageList.index(config.language))
         languageChoice.SetMinSize((150, -1))
 

--- a/eg/Classes/OptionsDialog.py
+++ b/eg/Classes/OptionsDialog.py
@@ -192,6 +192,7 @@ class OptionsDialog(eg.TaskletDialog):
             else:
                 languageChoice.Append(name)
         
+        # if no translation for language, default to English
         if config.language not in languageList:
             config.language='en_EN'
         

--- a/eg/Classes/SpinNumCtrl.py
+++ b/eg/Classes/SpinNumCtrl.py
@@ -22,10 +22,8 @@ from wx.lib import masked
 
 import eg
 
-l = wx.Locale()
-l.Init2(language=wx.LANGUAGE_DEFAULT, flags=wx.LOCALE_LOAD_DEFAULT)
-THOUSANDS_SEP = l.GetInfo(wx.LOCALE_THOUSANDS_SEP)
-DECIMAL_POINT = l.GetInfo(wx.LOCALE_DECIMAL_POINT)
+THOUSANDS_SEP = eg.app.locale.GetInfo(wx.LOCALE_THOUSANDS_SEP)
+DECIMAL_POINT = eg.app.locale.GetInfo(wx.LOCALE_DECIMAL_POINT)
 
 
 class SpinNumError(ValueError):


### PR DESCRIPTION
On first load of the options dialog an auto detect language is used, if this language doesn't exists the dialog will not open with exception trying to select an invalid language from the list.
solution if to default to English language.
If later on a translation for this language is created it will be added to the language list and will not be override to English.

