### PR TITLE
[Builder] - BugFix - InnoSetup.template

### DIFF
--- a/_build/data/InnoSetup.template
+++ b/_build/data/InnoSetup.template
@@ -61,7 +61,7 @@ begin
         Sleep(500)
       end;
       Success := RenameFile(Src, Dest)
-      Inc(i)
+      i := i + 1
     until (i = 20) or (Success = True);
     if (i = 20) then begin
       Result := False
@@ -180,7 +180,6 @@ Name: "{userstartup}\EventGhost"; Filename: "{app}\EventGhost.exe"; IconIndex: 1
 
 [Languages]
 Name: English; MessagesFile: "compiler:Default.isl"
-Name: Armenian; MessagesFile: "compiler:Languages\Armenian.islu"
 Name: BrazilianPortuguese; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
 Name: Catalan; MessagesFile: "compiler:Languages\Catalan.isl"
 Name: Corsican; MessagesFile: "compiler:Languages\Corsican.isl"
@@ -195,7 +194,6 @@ Name: Hebrew; MessagesFile: "compiler:Languages\Hebrew.isl"
 Name: Hungarian; MessagesFile: "compiler:Languages\Hungarian.isl"
 Name: Italian; MessagesFile: "compiler:Languages\Italian.isl"
 Name: Japanese; MessagesFile: "compiler:Languages\Japanese.isl"
-Name: Nepali; MessagesFile: "compiler:Languages\Nepali.islu"
 Name: Norwegian; MessagesFile: "compiler:Languages\Norwegian.isl"
 Name: Polish; MessagesFile: "compiler:Languages\Polish.isl"
 Name: Portuguese; MessagesFile: "compiler:Languages\Portuguese.isl"


### PR DESCRIPTION
In newer versions of InnoSetup they dropped support for 2 languages,
These languages have been removed from the template.

There was also a line in the template that was Inc(i) It appears as
tho that command may have been in older versions of InnoSetup Unicode
In the current documentation it is not listed. So I am going to assume
it has been removed. It is the same thing as doing i := i + 1 so
it was not a big deal to change it.