### PR TITLE
[Builder] - BugFix - CheckDependencies.py pip._veendor.requests traceback

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,7 @@ install:
         " "
         "--- pip 9.0.1"
         "    Updating..."
-        python -m pip install --no-cache-dir -q -U "pip==9.0.1"
+        python -m pip install --no-cache-dir -q -U pip
         "    Done."
         " "
         "--- setuptools 34.3.0"

--- a/_build/builder/CheckDependencies.py
+++ b/_build/builder/CheckDependencies.py
@@ -24,7 +24,6 @@ import re
 import sys
 import warnings
 from os.path import basename, exists, expandvars, join
-from pip._vendor import requests
 from shutil import copy2
 from string import digits
 
@@ -429,12 +428,13 @@ def CreateVirtualEnv():
     return result
 
 def DownloadFile(url, path = "%TEMP%"):
+    import urllib2
+
     file = expandvars(join(path, basename(url.split("?")[0])))
-    r = requests.get(url, stream=True)
+    data = urllib2.urlopen(url)
+
     with open(file, "wb") as f:
-        for chunk in r.iter_content(chunk_size=16384):
-            if chunk:
-                f.write(chunk)
+        f.write(data.read())
     return file
 
 def GetChocolateyPath():


### PR DESCRIPTION
There appears to be a glitch in version 18.1 of pip. I am not sure how
far back in the versions this problem goes. I do know that if you use
version 9.0.3 of pip when building EG everything is fine.

The problem produces a traceback when importing CheckDependencies

```python
    from pip._vendor import requests
  File "C:\Stackless27\lib\site-packages\pip\_vendor\requests\__init__.py", line 94, in <module>
    from pip._internal.utils.compat import WINDOWS
  File "C:\Stackless27\lib\site-packages\pip\_internal\__init__.py", line 40, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "C:\Stackless27\lib\site-packages\pip\_internal\cli\autocompletion.py", line 8, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "C:\Stackless27\lib\site-packages\pip\_internal\cli\main_parser.py", line 12, in <module>
    from pip._internal.commands import (
  File "C:\Stackless27\lib\site-packages\pip\_internal\commands\__init__.py", line 6, in <module>
    from pip._internal.commands.completion import CompletionCommand
  File "C:\Stackless27\lib\site-packages\pip\_internal\commands\completion.py", line 6, in <module>
    from pip._internal.cli.base_command import Command
  File "C:\Stackless27\lib\site-packages\pip\_internal\cli\base_command.py", line 18, in <module>
    from pip._internal.download import PipSession
  File "C:\Stackless27\lib\site-packages\pip\_internal\download.py", line 15, in <module>
    from pip._vendor import requests, six, urllib3
ImportError: cannot import name requests
```

They seem to have a broken dynamic import system. So I removed importing
requests from pip._vendor and replaced it with urllib2.urlopen