### PR TITLE
[EventGhost] - Obsolete - Removes ctypeslib as a dependency.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,7 +96,6 @@ install:
         PipInstall "py2exe 0.6.9" "py2exe_py2==0.6.9"
         PipInstall "pycrypto 2.6.1" "pycrypto==2.6.1"
         PipInstall "comtypes 1.1.3" "https://github.com/enthought/comtypes/archive/1.1.3.zip"
-        PipInstall "ctypeslib 0.5.6" "svn+http://svn.python.org/projects/ctypes/trunk/ctypeslib/#ctypeslib=0.5.6"
         PipInstall "paramiko 2.2.1" "paramiko==2.2.1"
         PipInstall "pywin32 223" pywin32==223
       }

--- a/_build/builder/CheckDependencies.py
+++ b/_build/builder/CheckDependencies.py
@@ -216,12 +216,6 @@ DEPENDENCIES = [
         version = "1.1.2",
     ),
     ModuleDependency(
-        name = "ctypeslib",
-        module = "ctypeslib",
-        version = "0.5.6",
-        url = "https://eventghost.github.io/dist/dependencies/ctypeslib-0.5.6-cp27-none-any.whl"
-    ),
-    ModuleDependency(
         name = "future",
         module = "future",
         version = "0.15.2",


### PR DESCRIPTION
Removes ctypeslib as a dependency.

From what I can find ctypeslib is only used to create WinApi.Dynamic
It is no longer being maintained. In order for it to run it requires.
GCC-XML which is also no longer being maintained. It has been succeeded 
by Cast-XML which is not compatible with ctypes lib. you can download 
an old version of GCC-XML the problem is that it only works with 
MSVC 6, 7 or 7.1. There is a fork on Pypi that uses Clang, but it is 
not complete and does not function for what EG would use it for.

what ctypeslib does is it creates python versions of C/C++ code.
What EG used it for was converting some of the Windows API.

I already have 500K lines of code of the Windows API converted from 
Windows Vista to the latest build of Windows 10. So it is pretty much 
obsolete and no longer needed.