### PR TITLE
ConfigPanel.py: Enables Apply button on first configure

### DIFF
--- a/eg/Classes/ConfigDialog.py
+++ b/eg/Classes/ConfigDialog.py
@@ -97,6 +97,12 @@ class ConfigDialog(eg.TaskletDialog):
         self.SetAcceleratorTable(
             wx.AcceleratorTable([(wx.ACCEL_NORMAL, wx.WXK_F1, wx.ID_HELP), ])
         )
+        
+    def OnApply(self, event):
+        if self.treeItem.isFirstConfigure:
+            self.buttonRow.okButton.Enable(True)
+
+        self.DispatchEvent(event, wx.ID_APPLY)
 
     @eg.LogItWithReturn
     def Configure(self, treeItem, *args):

--- a/eg/Classes/ConfigPanel.py
+++ b/eg/Classes/ConfigPanel.py
@@ -51,7 +51,9 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
         self.isDirty = False
         self.resultCode = None
         self.buttonsEnabled = True
-        self.dialog.buttonRow.applyButton.Enable(False)
+        self.dialog.buttonRow.applyButton.Enable(
+            self.dialog.treeItem.isFirstConfigure
+        )
         self.dialog.buttonRow.okButton.Enable(
             not self.dialog.treeItem.isFirstConfigure
         )

--- a/eg/Classes/PluginItem.py
+++ b/eg/Classes/PluginItem.py
@@ -194,7 +194,11 @@ class PluginItem(ActionItem):
             eg.actionThread.Call(self.info.Start)
 
     def SetAttributes(self, tree, itemId):
-        if self.info.lastException or self.info.initFailed:
+        if (
+            self.info is None or
+            self.info.lastException or
+            self.info.initFailed
+        ):
             tree.SetItemTextColour(itemId, eg.colour.pluginError)
 
     @eg.AssertInActionThread


### PR DESCRIPTION
If a Config dialog is opened for the first time the apply button will be enabled. On repeat opening of the dialog the Apply button will be disabled until a change is made. The act of clicking on the apply button will enable the OK button. 

The hope with this is that the user will need to actively view the settings in the config dialog and make sure they are correct before continuing. 

fixes #357