### PR TITLE
setting locale when Windows has no LCID for user selected locale settings

### DIFF
--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -31,7 +31,18 @@ import PythonPaths
 import LoopbackSocket
 
 ENCODING = locale.getdefaultlocale()[1]
-locale.setlocale(locale.LC_ALL, '')
+
+# Starting with Windows 10 build 1809 (I think) the behavior of setlocal has
+# changed. I believe they may have fixed a bug in setlocale that required the
+# passing of an empty string instead of NULL. So now we have to try both ways.
+
+try:
+    locale.setlocale(locale.LC_ALL, '')
+except locale.Error:
+    # Windows 10 build >= 1809
+    locale.setlocale(locale.LC_ALL, None)
+
+
 argvIter = (val.decode(ENCODING) for val in sys.argv)
 scriptPath = argvIter.next()
 


### PR DESCRIPTION
This is the easy solution to the setlocale problem.

I am not sure if this was due to a bug that Microsoft fixed, or if it is because they created a new bug. I think the issue started with Windows 10 build 1809. it appears as if the user has selected a language_locale combination that windows does not have an LCID assigned to the passing of an empty string to setlocale will fail. instead of passing an empty string we now pass None (NULL). This has been tested by a user on the forum. It should be tested again.

here is a list of language_locale variations that have no LCID assigned.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/926e694f-1797-4418-a922-343d1c5e91a6
