### PR TITLE
enable OK button for config dialog without options

### DIFF
--- a/eg/Classes/ConfigPanel.py
+++ b/eg/Classes/ConfigPanel.py
@@ -18,6 +18,7 @@
 
 import types
 import wx
+from inspect import currentframe, getargvalues, getouterframes
 
 # Local imports
 import eg
@@ -51,11 +52,14 @@ class ConfigPanel(wx.PyPanel, eg.ControlProviderMixin):
         self.isDirty = False
         self.resultCode = None
         self.buttonsEnabled = True
+        outer = getouterframes(currentframe())
+        has_args = len(getargvalues(outer[1][0]).args) > 1
         self.dialog.buttonRow.applyButton.Enable(
-            self.dialog.treeItem.isFirstConfigure
+            has_args and self.dialog.treeItem.isFirstConfigure
         )
         self.dialog.buttonRow.okButton.Enable(
-            not self.dialog.treeItem.isFirstConfigure
+            not has_args or
+            not (has_args and self.dialog.treeItem.isFirstConfigure)
         )
 
     def AddCtrl(self, ctrl):


### PR DESCRIPTION
If a config dialog is called with no parameters (`Configure()`) the Ok button is enabled, so the user can leave the dialog without needing to first click the apply button.