### PR TITLE
Broadcaster plugin bugfix

### DIFF
--- a/plugins/Broadcaster/__init__.py
+++ b/plugins/Broadcaster/__init__.py
@@ -212,7 +212,6 @@ class Broadcast(eg.ActionWithStringParameter):
             UDPSock.sendto(eg.ParseString(eventString).encode(eg.systemEncoding) + self.plugin.payDelim.encode(eg.systemEncoding) + payload,addr)
         UDPSock.close()
 
-
     def Configure(self, command="", payload="", port=0):
         text = self.text
         panel = eg.ConfigPanel(self)

--- a/plugins/Broadcaster/__init__.py
+++ b/plugins/Broadcaster/__init__.py
@@ -213,7 +213,7 @@ class Broadcast(eg.ActionWithStringParameter):
         UDPSock.close()
 
 
-    def Configure(self, command="", payload="", port=""):
+    def Configure(self, command="", payload="", port=0):
         text = self.text
         panel = eg.ConfigPanel(self)
 


### PR DESCRIPTION
Fixes traceback when opening send action. the traceback is caused by the default parameter port havinf a value of "" and not an integer