### PR TITLE
Fixes Main prefix when triggering an event from the command line.

### DIFF
--- a/eg/Cli.py
+++ b/eg/Cli.py
@@ -117,7 +117,7 @@ if args.isMain:
         arg = arg.lower()
 
         if arg in ('-e', '-event'):
-            eventstring = argvIter.next()
+            eventstring = str(argvIter.next())
             payloads = list()
             for payload in argvIter:
                 if payload.startswith('-'):
@@ -127,7 +127,18 @@ if args.isMain:
 
             if len(payloads) == 0:
                 payloads = None
-            args.startupEvent = (str(eventstring), payloads)
+
+            if '.' not in eventstring:
+                prefix = 'Main'
+                suffix = eventstring
+            else:
+                prefix, suffix = eventstring.split('.', 1)
+            
+            args.startupEvent = (
+                suffix,
+                payloads,
+                prefix
+            )
 
         if arg.startswith('-debug'):
             args.debugLevel = 1


### PR DESCRIPTION
When triggering an event form the command line even if the user has supplied a prefix and suffix "Main" gets set as the prefix. 

This fix does a check to see if a "." is in the event and if there is one then it sets the prefix and suffix accordingly.

Fixes #388